### PR TITLE
v1.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/src/Support/NotificationRegistry.php
+++ b/src/Support/NotificationRegistry.php
@@ -109,7 +109,7 @@ class NotificationRegistry
      *
      * @return array an array of associative arrays, each containing details about a parameter required by the constructor
      */
-    private function getNotificationClassParameters(string $notificationClass): array
+    private static function getNotificationClassParameters(string $notificationClass): array
     {
         // Make sure class exists
         if (!class_exists($notificationClass)) {


### PR DESCRIPTION
- (fix) make `NotificationRegistry` method `getNotificationClassParameters` static