### PR TITLE
fix: exception response handler

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -14,8 +14,7 @@ class Handler extends ExceptionHandler
      *
      * @var array
      */
-    protected $dontReport = [
-    ];
+    protected $dontReport = [];
 
     /**
      * A list of the inputs that are never flashed for validation exceptions.
@@ -96,6 +95,11 @@ class Handler extends ExceptionHandler
 
             case 'IntegratedVendorException':
                 return response()->error($exception->getMessage());
+        }
+
+        // if exception has JSON response return it
+        if (isset($exception->response) && $exception->response instanceof \Illuminate\Http\Response) {
+            return $exception->response;
         }
 
         if (app()->environment(['development', 'local'])) {


### PR DESCRIPTION
- fallback fix when instances don't properly send response from exception, then make sure the handler sends the response (we're not sure why but on some instances depending on platform - for example gcp the exception doesnt resolve to a response and ends up in the handler as the default BE response)