### PR TITLE
fix: Set default status to 'pending' for verification codes

### DIFF
--- a/src/Models/VerificationCode.php
+++ b/src/Models/VerificationCode.php
@@ -88,8 +88,9 @@ class VerificationCode extends Model
      */
     public static function generateFor($subject = null, $for = 'general_verification', $save = true)
     {
-        $verifyCode      = new static();
-        $verifyCode->for = $for;
+        $verifyCode         = new static();
+        $verifyCode->for    = $for;
+        $verifyCode->status = 'pending';  // Set default status
 
         if ($subject) {
             $verifyCode->setSubject($subject, false);


### PR DESCRIPTION
## Problem

The `VerificationCode` model was creating records with `NULL` status because the `generateFor()` method never initialized the status field.

This caused issues when querying for verification codes with:
```php
->where('status', 'pending')
```

All queries would fail to find the verification code, resulting in "Invalid or expired verification code" errors even with valid codes.

## Solution

Set `status = 'pending'` by default in the `generateFor()` method, which is called by both `generateEmailVerificationFor()` and `generateSmsVerificationFor()`.

## Changes

- Added `$verifyCode->status = 'pending';` in `generateFor()` method
- All verification codes now have proper status from creation

## Impact

Fixes verification flow for:
- Email verification codes
- SMS verification codes
- Registry developer account verification
- Any other code using the VerificationCode model

## Testing

After this fix, verification codes will be created with `status = 'pending'` and can be properly queried and validated.