### PR TITLE
fix: guard against null password in login() to prevent TypeError (hotfix)

### DIFF
--- a/src/Http/Controllers/Internal/v1/AuthController.php
+++ b/src/Http/Controllers/Internal/v1/AuthController.php
@@ -78,6 +78,18 @@ class AuthController extends Controller
             $query->where('email', $identity)->orWhere('phone', $identity);
         })->first();
 
+        // If the user exists but has no password set (e.g. invited via SSO or
+        // created without a password), prompt them to go through the forgot-password
+        // flow.  This guard MUST come before isInvalidPassword() which has a strict
+        // string type declaration and would throw a TypeError on a null value.
+        if ($user && empty($user->password)) {
+            return response()->error(
+                'No password is set for this account. Please use the forgot password flow to set one.',
+                400,
+                ['code' => 'reset_password']
+            );
+        }
+
         // Use a generic error message for both non-existent user and wrong password
         // to prevent user enumeration via differential error responses.
         if (!$user || Auth::isInvalidPassword($password, $user->password)) {
@@ -92,11 +104,6 @@ class AuthController extends Controller
                 'twoFaSession' => $twoFaSession,
                 'isEnabled'    => true,
             ]);
-        }
-
-        // If no password prompt user to reset password
-        if (empty($user->password)) {
-            return response()->error('Password reset required to continue.', 400, ['code' => 'reset_password']);
         }
 
         if ($user->isNotVerified() && $user->isNotAdmin()) {


### PR DESCRIPTION
## Problem

After merging PR #193, a `TypeError` was reported when a user with a `null` password attempts to log in:

```
Fleetbase\Support\Auth::isInvalidPassword(): Argument #2 ($hashedPassword) must be of type string, null given
```

This affects accounts that were created without a password (e.g. SSO-invited users, or accounts provisioned programmatically).

## Root Cause

In the patched `login()` method, the null-password guard existed but was placed **after** the call to `Auth::isInvalidPassword()`. That method has a strict `string` type declaration on its `$hashedPassword` parameter, so PHP throws a `TypeError` before the guard is ever reached.

## Fix

Move the null-password guard to **before** the `isInvalidPassword()` call:

```php
// Guard MUST come before isInvalidPassword() — which has a strict string
// type declaration — to avoid a TypeError on null.
if ($user && empty($user->password)) {
    return response()->error(
        'No password is set for this account. Please use the forgot password flow to set one.',
        400,
        ['code' => 'reset_password']
    );
}
```

When a user is found but has no password, the API now returns `HTTP 400` with `code: reset_password` and a clear message directing the user to the forgot-password flow. The frontend can use this error code to automatically redirect to the reset-password page.

## Files Changed

- `src/Http/Controllers/Internal/v1/AuthController.php`

Refs: GHSA-3wj9-hh56-7fw7