### PR TITLE
fix: prevent empty email/phone on user update

### DIFF
--- a/src/Http/Controllers/Internal/v1/UserController.php
+++ b/src/Http/Controllers/Internal/v1/UserController.php
@@ -8,6 +8,7 @@ use Fleetbase\Exceptions\FleetbaseRequestValidationException;
 use Fleetbase\Exports\UserExport;
 use Fleetbase\Http\Controllers\FleetbaseController;
 use Fleetbase\Http\Requests\CreateUserRequest;
+use Fleetbase\Http\Requests\UpdateUserRequest;
 use Fleetbase\Http\Requests\ExportRequest;
 use Fleetbase\Http\Requests\Internal\AcceptCompanyInvite;
 use Fleetbase\Http\Requests\Internal\InviteUserRequest;
@@ -56,6 +57,16 @@ class UserController extends FleetbaseController
      * @var CreateUserRequest
      */
     public $createRequest = CreateUserRequest::class;
+
+    /**
+     * Update user request.
+     *
+     * Enforces that email and phone cannot be set to an empty string
+     * and that uniqueness constraints are respected on update.
+     *
+     * @var UpdateUserRequest
+     */
+    public $updateRequest = UpdateUserRequest::class;
 
     /**
      * Creates a record with request payload.
@@ -126,6 +137,11 @@ class UserController extends FleetbaseController
      */
     public function updateRecord(Request $request, string $id)
     {
+        // Run the UpdateUserRequest validation rules before delegating to the
+        // model trait. This prevents email/phone being set to an empty string
+        // and enforces uniqueness constraints on partial (PATCH) updates.
+        $this->validateRequest($request);
+
         try {
             $record = $this->model->updateRecordFromRequest($request, $id, function (&$request, &$user) {
                 // Assign role if set

--- a/src/Http/Requests/UpdateUserRequest.php
+++ b/src/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Fleetbase\Http\Requests;
+
+use Fleetbase\Rules\EmailDomainExcluded;
+use Fleetbase\Rules\ValidPhoneNumber;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRequest extends FleetbaseRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return session('company');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * Uses `sometimes` + `required` (the correct Laravel pattern for PATCH/PUT):
+     * - If the field is present in the payload it must pass all rules, including
+     *   `required` which rejects empty strings and null.
+     * - If the field is absent entirely it is skipped, allowing partial updates.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        // Resolve the target user UUID from the route parameter so that the
+        // uniqueness rules can correctly ignore the user's own current value.
+        $userId = $this->route('id');
+
+        return [
+            'name'  => ['sometimes', 'required', 'string', 'min:2', 'max:100'],
+
+            // Email must be a valid address, must not be empty, and must remain
+            // unique across non-deleted users — ignoring the current user's own row.
+            'email' => [
+                'sometimes',
+                'required',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')
+                    ->ignore($userId, 'uuid')
+                    ->whereNull('deleted_at'),
+                new EmailDomainExcluded(),
+            ],
+
+            // Phone is optional (some user types may not have one), but if it is
+            // supplied it must be a valid E.164 number and must remain unique.
+            // `nullable` allows explicit null to clear the field; `required_with`
+            // is not used here because phone is genuinely optional on some accounts.
+            'phone' => [
+                'sometimes',
+                'nullable',
+                new ValidPhoneNumber(),
+                Rule::unique('users', 'phone')
+                    ->ignore($userId, 'uuid')
+                    ->whereNull('deleted_at'),
+            ],
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'name.required'   => 'Name cannot be empty.',
+            'name.min'        => 'Name must be at least 2 characters.',
+            'email.required'  => 'Email address cannot be empty.',
+            'email.email'     => 'A valid email address is required.',
+            'email.unique'    => 'An account with this email address already exists.',
+            'phone.unique'    => 'An account with this phone number already exists.',
+        ];
+    }
+}


### PR DESCRIPTION
## Problem

When editing a user from IAM, or when a user edits their own account, the `PUT/PATCH /int/v1/users/{id}` endpoint had **no dedicated form request**. This meant `email` and `phone` could be set to an empty string (or any arbitrary value) with no server-side validation.

## Root Cause

`UserController` had a `$createRequest` property pointing to `CreateUserRequest`, but no `$updateRequest` property. The `updateRecord()` override also called `updateRecordFromRequest()` directly, bypassing the trait's built-in `validateRequest()` call entirely.

## Changes

### `src/Http/Requests/UpdateUserRequest.php` (new file)

Uses the correct Laravel `sometimes` + `required` pattern for PATCH/PUT semantics:
- If a field is **present** in the payload it must pass all rules (`required` rejects empty strings and null).
- If a field is **absent** entirely it is skipped, allowing partial updates.

| Field | Rules |
|---|---|
| `email` | `sometimes`, `required`, valid email format, unique (ignoring own row), domain not excluded |
| `phone` | `sometimes`, `nullable`, valid E.164 format, unique (ignoring own row) |
| `name`  | `sometimes`, `required`, min 2 / max 100 chars |

The `Rule::unique()->ignore($userId, 'uuid')` clause ensures that saving a user's existing email or phone back does not incorrectly fail the uniqueness check.

### `src/Http/Controllers/Internal/v1/UserController.php` (modified)

1. Added `use Fleetbase\Http\Requests\UpdateUserRequest;` import.
2. Added `public $updateRequest = UpdateUserRequest::class;` property — hooks into `HasApiControllerBehavior::validateRequest()` automatically for PUT/PATCH requests.
3. Added explicit `$this->validateRequest($request);` at the top of the `updateRecord()` override, since that method calls `updateRecordFromRequest()` directly and would otherwise bypass validation.

## Testing

- Sending `PATCH /int/v1/users/{id}` with `{"user": {"email": ""}}` should now return `422` with `email cannot be empty`.
- Sending `PATCH /int/v1/users/{id}` with `{"user": {"phone": ""}}` should now return `422` with a phone validation error.
- Sending `PATCH /int/v1/users/{id}` with only `{"user": {"name": "New Name"}}` (no email/phone) should still succeed — partial updates are unaffected.
- Sending a user's own existing email back should still succeed — the `ignore()` clause handles this correctly.