### PR TITLE
fix: resolve currency code correctly for both list and associative-map shapes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.39",
+    "version": "1.6.40",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -1128,7 +1128,7 @@ class Utils
                 return [
                     'name'     => static::get($country, 'name.common'),
                     'iso2'     => static::get($country, 'cca2'),
-                    'currency' => static::get($country, 'currencies.0'),
+                    'currency' => static::resolveCurrencyCode(static::get($country, 'currencies', [])),
                 ];
             })
             ->values()
@@ -1136,7 +1136,7 @@ class Utils
         $countries = collect($countries);
 
         $data = $countries->first(function ($country) use ($currencyCode) {
-            return strtolower($country['currency']) === strtolower($currencyCode);
+            return is_string($country['currency']) && strtolower($country['currency']) === strtolower($currencyCode);
         });
 
         return static::get($data, 'iso2', $defaultValue);
@@ -1199,7 +1199,7 @@ class Utils
                     'aliases'     => static::get($country, 'alt_spellings', []),
                     'capital'     => static::get($country, 'capital_rinvex'),
                     'geo'         => static::get($country, 'geo'),
-                    'currency'    => Arr::first(static::get($country, 'currencies', [])),
+                    'currency'    => static::resolveCurrencyCode(static::get($country, 'currencies', [])),
                     'dial_code'   => Arr::first(static::get($country, 'calling_codes', [])),
                     'coordinates' => [
                         'longitude' => $longitude,
@@ -1215,6 +1215,53 @@ class Utils
         }
 
         return $data ?? null;
+    }
+
+    /**
+     * Resolve a currency code string from a currencies value returned by the PragmaRX Countries package.
+     *
+     * The package returns currencies in two distinct shapes depending on the data source:
+     *   - A sequential list of ISO 4217 code strings, e.g. ["USD", "EUR"]
+     *   - An associative map keyed by ISO 4217 code, e.g. {"USD": {"name": "...", "symbol": "..."}}
+     *
+     * When the value is a list, Arr::first() correctly returns the first code string.
+     * When the value is a map, Arr::first() returns the first *value* (an array), not the key.
+     * This method normalises both shapes and always returns the first currency code as a string,
+     * or null when no currencies are present.
+     *
+     * @param mixed $currencies the raw currencies value from the countries package
+     *
+     * @return string|null the first ISO 4217 currency code, or null if unavailable
+     */
+    public static function resolveCurrencyCode($currencies): ?string
+    {
+        if (empty($currencies)) {
+            return null;
+        }
+
+        // Convert Coollection / Eloquent Collection objects to a plain array so that
+        // both array_is_list() and array_key_first() work reliably.
+        if (is_object($currencies) && method_exists($currencies, 'toArray')) {
+            $currencies = $currencies->toArray();
+        }
+
+        if (!is_array($currencies)) {
+            return null;
+        }
+
+        // Sequential list shape: ["USD", "EUR", ...]
+        // The first element is already the ISO 4217 code string.
+        if (array_is_list($currencies)) {
+            $code = Arr::first($currencies);
+
+            return is_string($code) ? $code : null;
+        }
+
+        // Associative map shape: {"USD": {"name": "...", "symbol": "..."}, ...}
+        // The keys are the ISO 4217 code strings; the values are detail objects.
+        $code = array_key_first($currencies);
+
+        return is_string($code) ? $code : null;
     }
 
     /**


### PR DESCRIPTION
## Problem

Two related errors were reported in production:

```
DEPRECATED  mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated
            in vendor/laravel/framework/src/Illuminate/Support/Str.php on line 611.

TypeError: Fleetbase\Support\Utils::getCurrenyFromCountryCode(): Return value must be of type
           ?string, array returned  (Utils.php:1235)
```

### Root cause

The `fleetbase/countries` package (a fork of PragmaRX Countries) returns the `currencies` field in **two distinct shapes** depending on the underlying data source:

| Shape | Example | Scope |
|---|---|---|
| Sequential list of ISO 4217 strings | `["USD"]` | Most countries (239) |
| Associative map — code as key, detail object as value | `{"USD": {"name": "United States dollar", "symbol": "$"}}` | 10 territories: BQ, CC, CX, GP, GF, MQ, YT, RE, SJ, TK |

The previous code used `Arr::first()` unconditionally on the `currencies` collection:

```php
// Before
'currency' => Arr::first(static::get($country, 'currencies', [])),
```

- **List shape** — `Arr::first()` returns the first *element* (the code string). ✅
- **Map shape** — `Arr::first()` returns the first *value* (an array like `["name" => "...", "symbol" => "..."]`). ❌

This array then propagated into the cached country data and was returned from `getCurrenyFromCountryCode()`, whose return type is `?string`, causing the `TypeError`.

A secondary issue existed in `getCountryCodeByCurrency()` which used the dot-notation shorthand `currencies.0` (only valid for list-shape countries) and then called `strtolower($country['currency'])` without a null guard, triggering the `mb_strtolower(null)` deprecation for map-shape territories.

## Fix

Introduce a new `Utils::resolveCurrencyCode($currencies): ?string` helper that normalises both shapes:

```php
public static function resolveCurrencyCode($currencies): ?string
{
    if (empty($currencies)) {
        return null;
    }

    // Convert Coollection / Collection objects to a plain array.
    if (is_object($currencies) && method_exists($currencies, 'toArray')) {
        $currencies = $currencies->toArray();
    }

    if (!is_array($currencies)) {
        return null;
    }

    // Sequential list shape: ["USD", "EUR", ...]
    if (array_is_list($currencies)) {
        $code = Arr::first($currencies);
        return is_string($code) ? $code : null;
    }

    // Associative map shape: {"USD": {"name": "...", "symbol": "..."}, ...}
    $code = array_key_first($currencies);
    return is_string($code) ? $code : null;
}
```

### Changes

- **`getCountryData()`** — replace `Arr::first(...currencies...)` with `resolveCurrencyCode()` so the cached country data always stores a string currency code, never an array.
- **`getCountryCodeByCurrency()`** — replace `currencies.0` dot-notation with `resolveCurrencyCode()` (fixes map-shape countries), and add an `is_string()` guard before `strtolower()` to eliminate the `mb_strtolower(null)` deprecation.

## Affected territories

The following 10 territories had associative-map currencies and were broken before this fix:

| cca2 | Territory | Currency |
|---|---|---|
| BQ | Caribbean Netherlands | USD |
| CC | Cocos (Keeling) Islands | AUD |
| CX | Christmas Island | AUD |
| GP | Guadeloupe | EUR |
| GF | French Guiana | EUR |
| MQ | Martinique | EUR |
| YT | Mayotte | EUR |
| RE | Réunion | EUR |
| SJ | Svalbard and Jan Mayen | NOK |
| TK | Tokelau | NZD |
