### PR TITLE
fix: sync user/company to sandbox before creating test API key

### DIFF
--- a/src/Http/Controllers/Internal/v1/ApiCredentialController.php
+++ b/src/Http/Controllers/Internal/v1/ApiCredentialController.php
@@ -6,9 +6,14 @@ use Fleetbase\Exports\ApiCredentialExport;
 use Fleetbase\Http\Controllers\FleetbaseController;
 use Fleetbase\Http\Requests\ExportRequest;
 use Fleetbase\Models\ApiCredential;
+use Fleetbase\Models\Company;
+use Fleetbase\Models\CompanyUser;
+use Fleetbase\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -27,6 +32,132 @@ class ApiCredentialController extends FleetbaseController
      * @var string
      */
     public $service = 'developers';
+
+    /**
+     * Create a new API credential record.
+     *
+     * Overrides the generic createRecord to ensure that when a test/sandbox key
+     * is being created, the current user and company are mirrored into the sandbox
+     * database first. Without this, the foreign key constraint on `api_credentials.user_uuid`
+     * (which references `users.uuid` in the sandbox DB) will fail because the user
+     * and company rows only exist in the production database.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function createRecord(Request $request)
+    {
+        // Determine if this is a sandbox/test key creation request.
+        $isSandbox = \Fleetbase\Support\Utils::isTrue($request->header('Access-Console-Sandbox'));
+
+        if ($isSandbox) {
+            // Ensure the current user and company exist in the sandbox DB before
+            // attempting the insert, so the FK constraints are satisfied.
+            $this->syncCurrentSessionToSandbox($request);
+        }
+
+        return parent::createRecord($request);
+    }
+
+    /**
+     * Mirrors the currently authenticated user, their company, and the company–user
+     * membership record into the sandbox database.
+     *
+     * This is a targeted, on-demand version of the `sandbox:sync` Artisan command,
+     * scoped only to the records needed to satisfy the foreign key constraints when
+     * inserting a new test-mode `api_credentials` row.
+     *
+     * @param Request $request
+     *
+     * @return void
+     */
+    protected function syncCurrentSessionToSandbox(Request $request): void
+    {
+        $userUuid    = session('user');
+        $companyUuid = session('company');
+
+        if (!$userUuid || !$companyUuid) {
+            return;
+        }
+
+        // Temporarily disable FK checks so we can upsert in any order.
+        Schema::connection('sandbox')->disableForeignKeyConstraints();
+
+        try {
+            // --- Sync User ---
+            $user = User::on('mysql')->withoutGlobalScopes()->where('uuid', $userUuid)->first();
+            if ($user) {
+                $this->upsertModelToSandbox($user);
+            }
+
+            // --- Sync Company ---
+            $company = Company::on('mysql')->withoutGlobalScopes()->where('uuid', $companyUuid)->first();
+            if ($company) {
+                $this->upsertModelToSandbox($company);
+            }
+
+            // --- Sync CompanyUser pivot ---
+            $companyUser = CompanyUser::on('mysql')
+                ->withoutGlobalScopes()
+                ->where('user_uuid', $userUuid)
+                ->where('company_uuid', $companyUuid)
+                ->first();
+            if ($companyUser) {
+                $this->upsertModelToSandbox($companyUser);
+            }
+        } finally {
+            Schema::connection('sandbox')->enableForeignKeyConstraints();
+        }
+    }
+
+    /**
+     * Upserts a single Eloquent model record into the sandbox database.
+     *
+     * Mirrors the approach used in the `sandbox:sync` Artisan command:
+     * reduces the record to its fillable attributes, normalises datetime
+     * fields to strings, JSON-encodes any Json-cast columns, then performs
+     * an `updateOrInsert` keyed on `uuid`.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return void
+     */
+    protected function upsertModelToSandbox(\Illuminate\Database\Eloquent\Model $model): void
+    {
+        $clone = collect($model->toArray())
+            ->only($model->getFillable())
+            ->toArray();
+
+        if (!isset($clone['uuid']) || !is_string($clone['uuid'])) {
+            return;
+        }
+
+        // Normalise datetime columns to plain strings.
+        foreach ($clone as $key => $value) {
+            if (isset($clone[$key]) && Str::endsWith($key, '_at')) {
+                try {
+                    $clone[$key] = Carbon::parse($clone[$key])->toDateTimeString();
+                } catch (\Exception $e) {
+                    $clone[$key] = null;
+                }
+            }
+        }
+
+        // JSON-encode any Json-cast columns that are still arrays/objects.
+        $jsonColumns = collect($model->getCasts())
+            ->filter(fn ($cast) => Str::contains($cast, 'Json'))
+            ->keys()
+            ->toArray();
+
+        foreach ($clone as $key => $value) {
+            if (in_array($key, $jsonColumns) && (is_object($value) || is_array($value))) {
+                $clone[$key] = json_encode($value);
+            }
+        }
+
+        DB::connection('sandbox')
+            ->table($model->getTable())
+            ->updateOrInsert(['uuid' => $clone['uuid']], $clone);
+    }
 
     /**
      * Export the companies/users api credentials to excel or csv.


### PR DESCRIPTION
## Problem

When a user creates a test/sandbox API key (i.e. the request carries the `Access-Console-Sandbox: true` header), the `SetupFleetbaseSession` middleware calls `Auth::setSandboxSession($request)`, which switches `database.default` to `sandbox`. The subsequent `INSERT` into `api_credentials` therefore targets the **sandbox database**.

However, the `user_uuid` and `company_uuid` values populated by `fillSessionAttributes()` come from the **production session** — those rows exist in the production `users` and `companies` tables but are **not guaranteed to exist** in the sandbox database (unless the `sandbox:sync` Artisan command has been run manually).

The sandbox database enforces the same foreign key constraints as production:

```
CONSTRAINT `api_credentials_user_uuid_foreign`
  FOREIGN KEY (`user_uuid`) REFERENCES `users` (`uuid`)
  ON DELETE CASCADE ON UPDATE CASCADE
```

Because the referenced `users` row is absent in the sandbox DB, MySQL raises:

```
SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row:
a foreign key constraint fails (`fleetbase_production_sandbox`.`api_credentials`,
CONSTRAINT `api_credentials_user_uuid_foreign` …)
```

## Root Cause

The creation path for `ApiCredential` is entirely generic (via `HasApiControllerBehavior::createRecord` → `HasApiModelBehavior::createRecordFromRequest` → `static::create()`). There is no sandbox-aware pre-create step that ensures the referenced `users` / `companies` rows exist in the sandbox DB before the insert is attempted.

## Fix

Override `createRecord()` in `ApiCredentialController` to detect the sandbox header and, before delegating to the parent generic create path, mirror the current user, company, and `company_users` pivot row from production into the sandbox DB using an on-demand `updateOrInsert` upsert.

This is the same approach used by the `sandbox:sync` Artisan command (`SyncSandbox`), applied on-demand and scoped only to the three rows needed to satisfy the FK constraints:

1. `users` — satisfies `api_credentials_user_uuid_foreign`
2. `companies` — satisfies `api_credentials_company_uuid_foreign`
3. `company_users` — keeps the org-membership pivot consistent in sandbox

Foreign key checks are temporarily disabled during the upsert (identical to `sandbox:sync`) to avoid ordering issues, then re-enabled before the `api_credentials` insert proceeds.

## Files Changed

- `src/Http/Controllers/Internal/v1/ApiCredentialController.php`
  - Added `createRecord()` override that calls `syncCurrentSessionToSandbox()` when the sandbox header is present.
  - Added `syncCurrentSessionToSandbox()` — fetches the current user, company, and pivot from production and upserts them into sandbox.
  - Added `upsertModelToSandbox()` — reusable helper that mirrors a single model record into the sandbox DB (normalises datetimes, JSON-encodes Json-cast columns, upserts by `uuid`).

## Testing

1. Ensure the sandbox DB exists and has been migrated (`sandbox:migrate`).
2. Log in as any user whose `user_uuid` / `company_uuid` are **not** yet in the sandbox DB.
3. Open the Developers section and create a new **Test** API key.
4. Confirm the key is created without the `SQLSTATE[23000]` error.
5. Verify that the corresponding `users`, `companies`, and `company_users` rows now exist in the sandbox DB.