### PR TITLE
feat: schedule sandbox:sync to run hourly

### DIFF
--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -165,6 +165,13 @@ class CoreServiceProvider extends ServiceProvider
             $schedule->command('purge:scheduled-task-logs --force --no-interaction --days 1')->twiceDaily(1, 13);
             $schedule->command('telemetry:ping')->daily();
             $schedule->job(new \Fleetbase\Jobs\MaterializeSchedulesJob())->dailyAt('01:00')->name('materialize-schedules')->withoutOverlapping();
+            // Keep sandbox users/companies in sync with production so that
+            // test-mode API key creation (and other sandbox operations) never
+            // fail due to missing foreign-key referenced rows. Hourly cadence
+            // is a good balance: frequent enough that new users/companies are
+            // available in sandbox within an hour of being created in
+            // production, but infrequent enough to avoid unnecessary DB load.
+            $schedule->command('sandbox:sync')->hourly()->name('sandbox-sync')->withoutOverlapping();
         });
         $this->registerObservers();
         $this->registerExpansionsFrom();


### PR DESCRIPTION
## Summary

Registers the `sandbox:sync` Artisan command in the `CoreServiceProvider` scheduler so that production users and companies are periodically mirrored into the sandbox database automatically.

## Motivation

The sandbox database must contain matching `users` and `companies` rows for any sandbox operation that references those tables via foreign keys. Previously the only way to populate these rows was to run `php artisan sandbox:sync` manually, which meant a freshly provisioned instance (or any user who had never triggered a sync) would hit FK constraint errors.

PR #203 added an on-demand sync inside `ApiCredentialController::createRecord()` to fix the immediate test-key creation failure. This PR adds the complementary scheduled sync so the sandbox stays broadly consistent with production over time — covering all other sandbox operations beyond API key creation.

## Change

**File:** `src/Providers/CoreServiceProvider.php`

```php
$schedule->command('sandbox:sync')
    ->hourly()
    ->name('sandbox-sync')
    ->withoutOverlapping();
```

## Why hourly?

| Concern | Reasoning |
|---|---|
| **Freshness** | New production users/companies appear in sandbox within at most 60 minutes — acceptable for a development/testing environment. |
| **DB load** | `sandbox:sync` only performs `updateOrInsert` upserts on a small set of rows (`users`, `companies`, `api_credentials`). Running it every hour is negligible overhead. |
| **Safety** | `withoutOverlapping()` prevents concurrent runs if a sync takes longer than expected. |

A daily cadence would leave the sandbox stale for too long; anything more frequent than hourly (e.g. every 15 min) would be unnecessary given the lightweight on-demand sync already in place for the FK-critical path.