### PR TITLE
fix(iam): resolve correct route parameter in UpdateUserRequest

### DIFF
--- a/src/Http/Requests/UpdateUserRequest.php
+++ b/src/Http/Requests/UpdateUserRequest.php
@@ -32,7 +32,7 @@ class UpdateUserRequest extends FleetbaseRequest
     {
         // Resolve the target user UUID from the route parameter so that the
         // uniqueness rules can correctly ignore the user's own current value.
-        $userId = $this->route('id');
+        $userId = $this->route('user') ?? $this->route('id');
 
         return [
             'name'  => ['sometimes', 'required', 'string', 'min:2', 'max:100'],


### PR DESCRIPTION
This PR fixes a validation bug in the UpdateUserRequest that caused PUT/PATCH requests to fail with "Email/Phone already exists" errors when updating a user's own
  profile.

  The Problem:
  The UpdateUserRequest was strictly looking for a route parameter named id to identify the user being updated. However:
   - Standard RESTful routes generated by Fleetbase (via fleetbaseRoutes) use the singular resource name as the parameter, which is {user}.
   - Because $this->route('id') returned null, the uniqueness rules for email and phone were unable to ignore the current user's record, triggering a validation failure.

  The Fix:
  Updated the rules() method in UpdateUserRequest to resolve the user ID by checking both user and id parameters:
   1 $userId = $this->route('user') ?? $this->route('id');
  This ensures the validation correctly identifies and ignores the target user's existing values during partial or full updates across all routing configurations.

  Testing Performed:
   - Manual Reproduction: Confirmed that PUT /int/v1/users/{uuid} returned validation errors when providing the user's current email/phone.
   - Verification: Verified that after the change, the request succeeds and the user record is updated correctly.
   - Octane Compatibility: Verified that the change works correctly within the Octane/FrankenPHP environment after a worker restart.