### PR TITLE
Refresh records after API lifecycle hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.44",
+    "version": "1.6.45",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/src/Traits/HasApiModelBehavior.php
+++ b/src/Traits/HasApiModelBehavior.php
@@ -326,6 +326,15 @@ trait HasApiModelBehavior
             return $record;
         }
 
+        if (is_callable($onAfter)) {
+            $after = $onAfter($request, $record, $input);
+            if ($after instanceof JsonResponse) {
+                return $after;
+            }
+        }
+
+        $record->refresh();
+
         // PERFORMANCE OPTIMIZATION: Use load() instead of re-querying the database
         // This avoids an unnecessary second database query
         $with = $request->or(['with', 'expand'], []);
@@ -337,13 +346,6 @@ trait HasApiModelBehavior
         $withCount = $request->array('with_count', []);
         if (!empty($withCount)) {
             $record->loadCount($withCount);
-        }
-
-        if (is_callable($onAfter)) {
-            $after = $onAfter($request, $record, $input);
-            if ($after instanceof JsonResponse) {
-                return $after;
-            }
         }
 
         return static::mutateModelWithRequest($request, $record);
@@ -418,6 +420,15 @@ trait HasApiModelBehavior
             return $record;
         }
 
+        if (is_callable($onAfter)) {
+            $after = $onAfter($request, $record, $input);
+            if ($after instanceof JsonResponse) {
+                return $after;
+            }
+        }
+
+        $record->refresh();
+
         // PERFORMANCE OPTIMIZATION: Use load() instead of re-querying the database
         // This avoids an unnecessary second database query
         $with = $request->or(['with', 'expand'], []);
@@ -429,13 +440,6 @@ trait HasApiModelBehavior
         $withCount = $request->array('with_count', []);
         if (!empty($withCount)) {
             $record->loadCount($withCount);
-        }
-
-        if (is_callable($onAfter)) {
-            $after = $onAfter($request, $record, $input);
-            if ($after instanceof JsonResponse) {
-                return $after;
-            }
         }
 
         return static::mutateModelWithRequest($request, $record);


### PR DESCRIPTION
## Summary
- refresh API records after running lifecycle hooks before loading requested relations
- preserve JsonResponse short-circuit behavior from onAfter callbacks
- bump core-api version to 1.6.45

## Notes
- includes the local HasApiModelBehavior refresh ordering fix for create/update flows
