### PR TITLE
Fix request timezone precedence during user enrichment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.45",
+    "version": "1.6.46",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -7,6 +7,7 @@ use Fleetbase\Exceptions\InvalidVerificationCodeException;
 use Fleetbase\Notifications\UserCreated;
 use Fleetbase\Notifications\UserInvited;
 use Fleetbase\Support\NotificationRegistry;
+use Fleetbase\Support\Timezone;
 use Fleetbase\Support\Utils;
 use Fleetbase\Traits\ClearsHttpCache;
 use Fleetbase\Traits\Expandable;
@@ -1220,7 +1221,14 @@ class User extends Authenticatable
      */
     public static function applyUserInfoFromRequest($request, array $attributes = []): array
     {
-        $info = null;
+        $info         = null;
+        $timezone     = Timezone::firstValid([
+            $request->input('timezone'),
+            $request->input('whois.timezone'),
+            $request->input('whois.time_zone.name'),
+            data_get($attributes, 'timezone'),
+        ]);
+
         // Lookup user default details
         try {
             $info = \Fleetbase\Support\Http::lookupIp($request);
@@ -1230,10 +1238,16 @@ class User extends Authenticatable
         if ($info) {
             $attributes['country']    = data_get($info, 'country_code');
             $attributes['ip_address'] = data_get($info, 'ip', $request->ip());
-            $tzInfo                   = data_get($info, 'time_zone.name', $request->input('timezone'));
-            if ($tzInfo) {
-                $attributes['timezone'] = $tzInfo;
+            $timezone                 = $timezone ?: Timezone::firstValid([
+                data_get($info, 'time_zone.name'),
+                data_get($info, 'timezone'),
+                data_get($info, 'timezone_name'),
+            ]);
+
+            if ($timezone) {
+                $attributes['timezone'] = $timezone;
             }
+
             $attributes['meta'] = [
                 'areacode'   => data_get($info, 'calling_code'),
                 'currency'   => data_get($info, 'currency.code'),
@@ -1243,6 +1257,10 @@ class User extends Authenticatable
                 'latitude'   => data_get($info, 'latitude'),
                 'longitude'  => data_get($info, 'longitude'),
             ];
+        }
+
+        if ($timezone) {
+            $attributes['timezone'] = $timezone;
         }
 
         return $attributes;

--- a/src/Support/Timezone.php
+++ b/src/Support/Timezone.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fleetbase\Support;
+
+class Timezone
+{
+    /**
+     * Return the first valid IANA timezone from a list of candidates.
+     */
+    public static function firstValid(array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate) || trim($candidate) === '') {
+                continue;
+            }
+
+            $candidate = trim($candidate);
+            if (in_array($candidate, \DateTimeZone::listIdentifiers(), true)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/TimezoneTest.php
+++ b/tests/Unit/TimezoneTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Fleetbase\Support\Timezone;
+
+test('first valid timezone preserves request precedence order', function () {
+    $timezone = Timezone::firstValid([
+        'America/New_York',
+        'Asia/Singapore',
+    ]);
+
+    expect($timezone)->toBe('America/New_York');
+});
+
+test('first valid timezone accepts nested whois timezone candidates', function () {
+    $timezone = Timezone::firstValid([
+        null,
+        'Europe/London',
+        'Asia/Singapore',
+    ]);
+
+    expect($timezone)->toBe('Europe/London');
+});
+
+test('first valid timezone ignores invalid values', function () {
+    $timezone = Timezone::firstValid([
+        'Not/A_Timezone',
+        'Also/Invalid',
+    ]);
+
+    expect($timezone)->toBeNull();
+});
+
+test('first valid timezone does not default to application timezone', function () {
+    $timezone = Timezone::firstValid([
+        null,
+        '',
+    ]);
+
+    expect($timezone)->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add shared IANA timezone helper
- preserve request/browser timezone before backend IP lookup timezone
- support whois.timezone and whois.time_zone.name candidates
- avoid falling back to application/server timezone when no valid timezone exists

## Verification
- php -l src/Support/Timezone.php src/Models/User.php tests/Unit/TimezoneTest.php
- vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no src/Models/User.php
- vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no src/Support/Timezone.php
- vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no tests/Unit/TimezoneTest.php
- vendor/bin/pest --colors=always tests/Unit/TimezoneTest.php

Note: Pest passed, but emitted an existing sandbox warning writing vendor/pestphp/pest/.temp/test-results.