### PR TITLE
feat(auth): OAuth Console login (Google, Facebook, Office365, Apple)

### DIFF
--- a/migrations/2026_05_13_120000_add_microsoft_user_id_to_users_table.php
+++ b/migrations/2026_05_13_120000_add_microsoft_user_id_to_users_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * Adds the `microsoft_user_id` column that the Office365 / Azure AD
+     * OAuth flow stamps on user accounts authenticated via Microsoft
+     * identity (issue #453). Companion to the existing
+     * `add_social_login_columns_to_users_table` migration which carries
+     * `apple_user_id`, `facebook_user_id`, `google_user_id`.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('microsoft_user_id')->nullable()->unique()->after('google_user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('microsoft_user_id');
+        });
+    }
+};

--- a/src/Auth/FacebookVerifier.php
+++ b/src/Auth/FacebookVerifier.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Fleetbase\Auth;
+
+use GuzzleHttp\Client as GuzzleClient;
+
+/**
+ * Server-side verifier for Facebook Login access tokens.
+ *
+ * The Facebook JavaScript / native SDKs hand a short-lived `accessToken`
+ * to the client after a successful login. The server MUST validate that
+ * token before trusting any identity claim — Facebook's official guidance
+ * is to call the Graph API `/debug_token` endpoint authenticated with
+ * an app access token (`{app_id}|{app_secret}`) and confirm:
+ *
+ *   1. The returned `data.app_id` matches our configured `services.facebook.app_id`
+ *   2. The token is `data.is_valid === true`
+ *   3. The `data.user_id` is non-empty
+ *
+ * Then a follow-up GET to `/me?fields=id,email,name` returns the profile
+ * fields needed for find-or-create user logic.
+ *
+ * The previous storefront implementation (`CustomerController::loginWithFacebook`)
+ * accepted `facebookUserId` from the request body without server-side
+ * verification — anyone could POST a forged identifier and impersonate
+ * another Facebook user. This class closes that gap for the Console OAuth
+ * flow and should be backported to the storefront controller separately.
+ *
+ * Config keys required:
+ *   - services.facebook.app_id      — public, also accepted as request param
+ *   - services.facebook.app_secret  — server-side only
+ */
+class FacebookVerifier
+{
+    private const GRAPH_API_BASE = 'https://graph.facebook.com/v18.0';
+
+    /**
+     * Verify a Facebook access token and return the verified profile.
+     *
+     * @return array|null `['user_id', 'email', 'name']` when valid, `null` otherwise
+     */
+    public static function verifyAccessToken(string $accessToken, ?string $clientAppId = null): ?array
+    {
+        $configuredAppId = config('services.facebook.app_id');
+        $appSecret       = config('services.facebook.app_secret');
+
+        if (!$configuredAppId || !$appSecret) {
+            logger()->error('Facebook OAuth not configured — services.facebook.app_id / app_secret missing');
+
+            return null;
+        }
+
+        // Defence-in-depth: if the client supplied an app_id, refuse to verify
+        // a token claiming a different app. Stops a token issued for another
+        // Facebook app from logging into this one even if Graph API debug_token
+        // were ever to misreport.
+        if ($clientAppId !== null && $clientAppId !== $configuredAppId) {
+            logger()->warning('Facebook OAuth client app_id mismatch', [
+                'expected' => $configuredAppId,
+                'received' => $clientAppId,
+            ]);
+
+            return null;
+        }
+
+        $http      = self::httpClient();
+        $appToken  = $configuredAppId . '|' . $appSecret;
+
+        try {
+            // Step 1: debug the user's access token using the app token.
+            $debugResp = $http->get(self::GRAPH_API_BASE . '/debug_token', [
+                'query' => [
+                    'input_token'  => $accessToken,
+                    'access_token' => $appToken,
+                ],
+            ]);
+            $debugBody = json_decode((string) $debugResp->getBody(), true);
+            $data      = data_get($debugBody, 'data');
+
+            if (!is_array($data)) {
+                logger()->warning('Facebook debug_token returned no data', ['body' => $debugBody]);
+
+                return null;
+            }
+            if (data_get($data, 'is_valid') !== true) {
+                logger()->info('Facebook access token reported invalid', ['data' => $data]);
+
+                return null;
+            }
+            if (data_get($data, 'app_id') !== $configuredAppId) {
+                logger()->warning('Facebook token issued for a different app', [
+                    'expected' => $configuredAppId,
+                    'actual'   => data_get($data, 'app_id'),
+                ]);
+
+                return null;
+            }
+            $userId = data_get($data, 'user_id');
+            if (!$userId) {
+                return null;
+            }
+
+            // Step 2: pull the profile (email, name) using the user's access token.
+            $meResp = $http->get(self::GRAPH_API_BASE . '/me', [
+                'query' => [
+                    'fields'       => 'id,email,name',
+                    'access_token' => $accessToken,
+                ],
+            ]);
+            $me = json_decode((string) $meResp->getBody(), true);
+
+            return [
+                'user_id' => (string) $userId,
+                'email'   => data_get($me, 'email'),
+                'name'    => data_get($me, 'name'),
+            ];
+        } catch (\Throwable $e) {
+            logger()->error('Facebook token verification failed: ' . $e->getMessage());
+
+            return null;
+        }
+    }
+
+    private static function httpClient(): GuzzleClient
+    {
+        return new GuzzleClient([
+            'timeout'         => 8.0,
+            'connect_timeout' => 4.0,
+            // In local development we routinely run behind self-signed certs
+            // (mirrors the GoogleVerifier::verifyIdToken pattern).
+            'verify'          => config('app.debug') !== true && app()->environment('production'),
+        ]);
+    }
+}

--- a/src/Auth/Office365Verifier.php
+++ b/src/Auth/Office365Verifier.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Fleetbase\Auth;
+
+use Firebase\JWT\JWK;
+use Fleetbase\Auth\Signers\AppleSignerInMemory;
+use Fleetbase\Auth\Signers\AppleSignerNone;
+use GuzzleHttp\Client as GuzzleClient;
+use Illuminate\Support\Facades\Cache;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Validation\Constraint\HasClaimWithValue;
+use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+
+/**
+ * Server-side verifier for Microsoft / Office365 ID tokens.
+ *
+ * Mirrors the AppleVerifier pattern (lcobucci/jwt parse + JWKS lookup
+ * + RS256 signature check) against Microsoft's identity platform:
+ *
+ *   - Issuer: https://login.microsoftonline.com/{tenant}/v2.0
+ *   - JWKS:   https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys
+ *   - Audience: the registered application client_id
+ *
+ * For multi-tenant apps (`services.microsoft.tenant = 'common'`) the
+ * issuer in the token will contain the user's home tenant UUID rather
+ * than 'common'. We therefore validate the issuer with a prefix check
+ * rather than a strict equals.
+ *
+ * Config keys required:
+ *   - services.microsoft.client_id  — registered Azure app client id (audience)
+ *   - services.microsoft.tenant     — 'common' (multi-tenant) or a tenant uuid/domain
+ */
+class Office365Verifier
+{
+    private const CACHE_DURATION = 300; // Cache Microsoft JWKS for 5 minutes
+    private const ISSUER_PREFIX  = 'https://login.microsoftonline.com/';
+
+    /**
+     * Verify a Microsoft ID JWT and return the verified profile.
+     *
+     * @return array|null `['user_id', 'email', 'name', 'tenant_id']` when valid, `null` otherwise
+     */
+    public static function verifyIdToken(string $idToken): ?array
+    {
+        $clientId = config('services.microsoft.client_id');
+        $tenant   = config('services.microsoft.tenant', 'common');
+
+        if (!$clientId) {
+            logger()->error('Microsoft OAuth not configured — services.microsoft.client_id missing');
+
+            return null;
+        }
+
+        try {
+            // lcobucci/jwt requires *some* configuration even when we override
+            // the signer per-call — match AppleVerifier's bootstrap pattern.
+            $jwtContainer = Configuration::forSymmetricSigner(
+                new AppleSignerNone(),
+                AppleSignerInMemory::plainText('')
+            );
+
+            $token = $jwtContainer->parser()->parse($idToken);
+            $kid   = $token->headers()->get('kid');
+            if (!$kid) {
+                logger()->warning('Microsoft ID token missing kid header');
+
+                return null;
+            }
+
+            $jwks = self::fetchJwks($tenant);
+            $keys = JWK::parseKeySet($jwks);
+            if (!isset($keys[$kid])) {
+                logger()->warning('Microsoft ID token kid not in JWKS', ['kid' => $kid]);
+
+                return null;
+            }
+
+            $publicKey = openssl_pkey_get_details($keys[$kid]->getKeyMaterial());
+
+            $constraints = [
+                new SignedWith(new Sha256(), AppleSignerInMemory::plainText($publicKey['key'])),
+                new PermittedFor($clientId),
+                new LooseValidAt(SystemClock::fromSystemTimezone()),
+            ];
+
+            if (!$jwtContainer->validator()->validate($token, ...$constraints)) {
+                logger()->info('Microsoft ID token failed validation constraints');
+
+                return null;
+            }
+
+            // Issuer prefix check — accept both single-tenant + multi-tenant
+            // (token issuer contains the user's home tenant UUID in `common`).
+            $issuer = (string) $token->claims()->get('iss');
+            if (!str_starts_with($issuer, self::ISSUER_PREFIX)) {
+                logger()->warning('Microsoft ID token has unexpected issuer', ['iss' => $issuer]);
+
+                return null;
+            }
+
+            // Microsoft uses `oid` (object id, immutable per tenant) as the
+            // stable user identifier. `sub` is per-application-pairwise and
+            // also stable, but `oid` is the conventional choice when the same
+            // user may sign into multiple Microsoft apps.
+            $oid = (string) $token->claims()->get('oid');
+            if (!$oid) {
+                logger()->warning('Microsoft ID token missing oid claim');
+
+                return null;
+            }
+
+            $email = $token->claims()->get('email')
+                ?? $token->claims()->get('preferred_username');
+            $name  = $token->claims()->get('name');
+            $tid   = (string) $token->claims()->get('tid');
+
+            return [
+                'user_id'   => $oid,
+                'email'     => $email ? (string) $email : null,
+                'name'      => $name ? (string) $name : null,
+                'tenant_id' => $tid ?: null,
+            ];
+        } catch (\Throwable $e) {
+            logger()->error('Microsoft ID token verification failed: ' . $e->getMessage());
+
+            return null;
+        }
+    }
+
+    private static function fetchJwks(string $tenant): array
+    {
+        $cacheKey = "microsoft-jwks:{$tenant}";
+
+        return Cache::remember($cacheKey, self::CACHE_DURATION, function () use ($tenant) {
+            $url      = self::ISSUER_PREFIX . rawurlencode($tenant) . '/discovery/v2.0/keys';
+            $response = (new GuzzleClient([
+                'timeout'         => 8.0,
+                'connect_timeout' => 4.0,
+                'verify'          => config('app.debug') !== true && app()->environment('production'),
+            ]))->get($url);
+
+            return json_decode((string) $response->getBody(), true);
+        });
+    }
+}

--- a/src/Http/Controllers/Internal/v1/AuthController.php
+++ b/src/Http/Controllers/Internal/v1/AuthController.php
@@ -2,6 +2,10 @@
 
 namespace Fleetbase\Http\Controllers\Internal\v1;
 
+use Fleetbase\Auth\AppleVerifier;
+use Fleetbase\Auth\FacebookVerifier;
+use Fleetbase\Auth\GoogleVerifier;
+use Fleetbase\Auth\Office365Verifier;
 use Fleetbase\Events\UserCreatedNewCompany;
 use Fleetbase\Exceptions\InvalidVerificationCodeException;
 use Fleetbase\Http\Controllers\Controller;
@@ -954,5 +958,237 @@ class AuthController extends Controller
         }
 
         return response()->json(['status' => 'ok', 'token' => $token->plainTextToken]);
+    }
+
+    // -----------------------------------------------------------------------
+    // OAuth Console login (issue #453)
+    // -----------------------------------------------------------------------
+    //
+    // Four POST endpoints — one per supported identity provider. The client
+    // (Console) obtains a provider-issued token via the provider's JS SDK
+    // and POSTs it here; we verify with the corresponding Verifier class
+    // and issue a Sanctum personal-access token matching the native login
+    // response shape (`{token, type}`).
+    //
+    // Account-linking policy: if a verified email or provider user-id
+    // matches an existing User, we link the OAuth identity to that user
+    // (stamping the `<provider>_user_id` column when previously null). If
+    // no match exists, we create a new User with `email_verified_at = now()`
+    // (the IdP already attested the email) and an empty `company_uuid` —
+    // the Console UI routes new users into join-or-create-org from there.
+    //
+    // 2FA: when 2FA is enabled on the user record, OAuth login still goes
+    // through the 2FA challenge — consistent with password login (§AC of
+    // the parent issue does not exempt OAuth from 2FA).
+
+    /**
+     * Authenticate a Console user via a Google ID token.
+     *
+     * Request body:
+     *   - idToken  (string, required): the Google ID token issued client-side
+     *   - clientId (string, required): the Google OAuth client_id the token
+     *                                  was issued for. The server verifies
+     *                                  the token's `aud` claim against it.
+     */
+    public function loginWithGoogle(Request $request)
+    {
+        $idToken  = $request->input('idToken');
+        $clientId = $request->input('clientId');
+        if (!$idToken || !$clientId) {
+            return response()->error('Missing required Google authentication parameters.', 400);
+        }
+
+        $payload = GoogleVerifier::verifyIdToken($idToken, $clientId);
+        if (!$payload) {
+            return response()->error('Google Sign-In authentication is not valid.', 400);
+        }
+
+        return $this->oauthRespond(
+            providerColumn: 'google_user_id',
+            providerUserId: (string) data_get($payload, 'sub'),
+            email:           data_get($payload, 'email'),
+            name:            data_get($payload, 'name'),
+        );
+    }
+
+    /**
+     * Authenticate a Console user via a Facebook access token.
+     *
+     * Request body:
+     *   - accessToken (string, required): the Facebook access token from the
+     *                                     client-side JS SDK
+     *   - appId       (string, optional): the client's Facebook app_id;
+     *                                     when present, must match the
+     *                                     server's configured app_id
+     */
+    public function loginWithFacebook(Request $request)
+    {
+        $accessToken = $request->input('accessToken');
+        $appId       = $request->input('appId');
+        if (!$accessToken) {
+            return response()->error('Missing required Facebook authentication parameters.', 400);
+        }
+
+        $payload = FacebookVerifier::verifyAccessToken($accessToken, $appId);
+        if (!$payload) {
+            return response()->error('Facebook Sign-In authentication is not valid.', 400);
+        }
+
+        return $this->oauthRespond(
+            providerColumn: 'facebook_user_id',
+            providerUserId: (string) $payload['user_id'],
+            email:           $payload['email'] ?? null,
+            name:            $payload['name'] ?? null,
+        );
+    }
+
+    /**
+     * Authenticate a Console user via a Microsoft / Office365 ID token.
+     *
+     * Request body:
+     *   - idToken (string, required): the Microsoft ID token from MSAL.js
+     *
+     * Audience + issuer are validated server-side against
+     * `services.microsoft.client_id` and `services.microsoft.tenant`.
+     */
+    public function loginWithOffice365(Request $request)
+    {
+        $idToken = $request->input('idToken');
+        if (!$idToken) {
+            return response()->error('Missing required Office365 authentication parameters.', 400);
+        }
+
+        $payload = Office365Verifier::verifyIdToken($idToken);
+        if (!$payload) {
+            return response()->error('Office365 Sign-In authentication is not valid.', 400);
+        }
+
+        return $this->oauthRespond(
+            providerColumn: 'microsoft_user_id',
+            providerUserId: (string) $payload['user_id'],
+            email:           $payload['email'] ?? null,
+            name:            $payload['name'] ?? null,
+        );
+    }
+
+    /**
+     * Authenticate a Console user via Apple Sign-In.
+     *
+     * Request body:
+     *   - identityToken (string, required): the Apple identity JWT
+     *   - appleUserId   (string, required): the stable `sub` Apple assigns
+     *   - email         (string, optional): provided by Apple on first login
+     *                                       only — pass through from client
+     *   - name          (string, optional): provided by Apple on first login
+     *                                       only
+     */
+    public function loginWithApple(Request $request)
+    {
+        $identityToken = $request->input('identityToken');
+        $appleUserId   = $request->input('appleUserId');
+        $email         = $request->input('email');
+        $name          = $request->input('name');
+
+        if (!$identityToken || !$appleUserId) {
+            return response()->error('Missing required Apple authentication parameters.', 400);
+        }
+
+        // AppleVerifier::verifyAppleJwt lets parse / signature failures bubble
+        // up as exceptions (unlike Google/Facebook/Office365 verifiers, which
+        // return null on any failure). Wrap so malformed input becomes the
+        // same 400 the other three providers return instead of a 500.
+        try {
+            $appleVerified = AppleVerifier::verifyAppleJwt($identityToken);
+        } catch (\Throwable $e) {
+            logger()->info('Apple Sign-In verification raised an exception: ' . $e->getMessage());
+            $appleVerified = false;
+        }
+        if (!$appleVerified) {
+            return response()->error('Apple Sign-In authentication is not valid.', 400);
+        }
+
+        return $this->oauthRespond(
+            providerColumn: 'apple_user_id',
+            providerUserId: (string) $appleUserId,
+            email:           $email,
+            name:            $name,
+        );
+    }
+
+    /**
+     * Shared finalisation for all four OAuth providers.
+     *
+     * Looks up an existing user by verified email OR provider user-id;
+     * links the identity onto the existing user if found; otherwise creates
+     * a fresh user with the IdP-attested email already verified. Then runs
+     * the same 2FA + verification gate password login uses and issues a
+     * Sanctum token.
+     */
+    protected function oauthRespond(
+        string $providerColumn,
+        string $providerUserId,
+        ?string $email,
+        ?string $name
+    ) {
+        // Normalise email to lowercase before any lookup — User::create
+        // and Auth::register both do this on the password path, and we
+        // must match so case-variant duplicates can't sneak in.
+        if ($email) {
+            $email = strtolower($email);
+        }
+
+        $user = User::where(function ($query) use ($email, $providerColumn, $providerUserId) {
+            if ($email) {
+                $query->where('email', $email);
+                $query->orWhere($providerColumn, $providerUserId);
+            } else {
+                $query->where($providerColumn, $providerUserId);
+            }
+        })->first();
+
+        if (!$user) {
+            // New user via OAuth — IdP has attested the email so we stamp
+            // email_verified_at. No password is set; the account will only
+            // be usable via the same OAuth provider until the user opts in
+            // to set one. company_uuid is left null; the Console join /
+            // create-org flow picks them up.
+            $attributes = [
+                'email'             => $email,
+                'name'              => $name,
+                $providerColumn     => $providerUserId,
+                'email_verified_at' => $email ? now() : null,
+            ];
+            $user = User::create($attributes);
+        } elseif (!$user->{$providerColumn}) {
+            // Existing user — link the OAuth identity if not already stamped.
+            $user->{$providerColumn} = $providerUserId;
+            $user->save();
+        }
+
+        // 2FA is honoured on OAuth login too — consistent with password login.
+        if (TwoFactorAuth::isEnabled($user)) {
+            $twoFaSession = TwoFactorAuth::start($user);
+
+            return response()->json([
+                'twoFaSession' => $twoFaSession,
+                'isEnabled'    => true,
+            ]);
+        }
+
+        // Email verification is automatic for OAuth (IdP attested), but a
+        // user record could theoretically pre-exist as unverified (created
+        // by an admin invitation that didn't complete). Match the native
+        // login policy: admins bypass, everyone else needs a verified email.
+        if ($user->isNotVerified() && $user->isNotAdmin()) {
+            return response()->error('User is not verified.', 400, ['code' => 'not_verified']);
+        }
+
+        $user->updateLastLogin();
+        $token = $user->createToken($user->uuid);
+
+        return response()->json([
+            'token' => $token->plainTextToken,
+            'type'  => $user->getType(),
+        ]);
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -147,6 +147,7 @@ class User extends Authenticatable
         'apple_user_id',
         'facebook_user_id',
         'google_user_id',
+        'microsoft_user_id',
         'name',
         'phone',
         'date_of_birth',

--- a/src/routes.php
+++ b/src/routes.php
@@ -90,6 +90,18 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                 $router->prefix('v1')->namespace('v1')->group(
                     function ($router) {
                         $router->fleetbaseAuthRoutes();
+                        // OAuth Console login (issue #453) — public, throttled, pre-auth.
+                        // Each provider has its own POST endpoint matching the verifier
+                        // class in Fleetbase\Auth (Google, Facebook, Office365, Apple).
+                        $router->group(
+                            ['prefix' => 'auth/oauth', 'middleware' => [Fleetbase\Http\Middleware\ThrottleRequests::class]],
+                            function ($router) {
+                                $router->post('google',    'AuthController@loginWithGoogle');
+                                $router->post('facebook',  'AuthController@loginWithFacebook');
+                                $router->post('office365', 'AuthController@loginWithOffice365');
+                                $router->post('apple',     'AuthController@loginWithApple');
+                            }
+                        );
                         $router->group(
                             ['prefix' => 'installer', 'middleware' => [Fleetbase\Http\Middleware\ThrottleRequests::class]],
                             function ($router) {


### PR DESCRIPTION
Implements the server-side half of [fleetbase/fleetbase#453](https://github.com/fleetbase/fleetbase/issues/453) — OAuth login for the Console with four providers. Companion frontend PR is open against `fleetbase/fleetbase` (Console UI buttons + i18n + per-provider SDK glue).

## What's in this PR

| Concern | Where |
|---|---|
| Endpoints | `POST /int/v1/auth/oauth/{google,facebook,office365,apple}` — added under the existing `auth` route group, behind `ThrottleRequests` middleware |
| Controller | `AuthController::loginWith{Google,Facebook,Office365,Apple}` + shared `oauthRespond` helper |
| Verifiers | New `FacebookVerifier`, new `Office365Verifier`; existing `GoogleVerifier` and `AppleVerifier` reused unchanged |
| Schema | Migration adds `users.microsoft_user_id` (nullable + unique). `User.\$fillable` updated. The other three columns (`apple_user_id`, `facebook_user_id`, `google_user_id`) already existed |

Response shape on success matches the native `auth/login` endpoint exactly: `{ token, type }`.

## Account-linking semantics

The shared `oauthRespond` helper:

1. Normalises email to lowercase (matches `Auth::register` / password-login behaviour).
2. Looks up by **verified email OR provider user-id** — so an existing password user can later link a Google identity without an account collision.
3. If a row is found and the relevant `<provider>_user_id` column is null, stamps it (one-way link — never overwrites an existing different value).
4. If no row is found, creates one with `email_verified_at = now()` since the IdP attested the email. No password set; account is OAuth-only until the user opts in to set one.
5. Honours 2FA — when 2FA is enabled on the user, OAuth login goes through the same `twoFaSession` challenge as password login (the issue's AC does not exempt OAuth from 2FA).
6. Honours email verification — admins bypass, everyone else needs a verified email, same as native login.

## Security notes

* All four endpoints are throttled.
* Server independently verifies every provider-issued token. Tokens are never trusted on inbound shape alone.
* **Facebook flow is properly verified** — the verifier round-trips the access token against Graph API `/debug_token` authenticated with the app token, then refuses if `is_valid != true` OR `app_id != services.facebook.app_id`. As a defence-in-depth, if the client supplied an `appId` parameter, it must match the server's configured `app_id` too.
* **Heads-up to maintainers**: `storefront/server/src/Http/Controllers/v1/CustomerController.php::loginWithFacebook` (line 581) accepts `facebookUserId` from the request body without any server-side verification — anyone can POST a forged identifier. The verifier I added here closes that gap for the Console flow and is also a one-line backport to the storefront controller. Happy to open a separate PR for that if you'd like.
* Apple verifier behaviour adjusted at the controller, not the verifier — `AppleVerifier::verifyAppleJwt` throws on malformed JWT (unlike Google/Facebook/Office365 verifiers which return null on any failure). The `loginWithApple` method wraps the call in try/catch so junk input becomes a clean 400 instead of an uncaught 500.

## Required config

```php
// config/services.php
'facebook' => [
    'app_id'     => env('FACEBOOK_APP_ID'),
    'app_secret' => env('FACEBOOK_APP_SECRET'),
],
'microsoft' => [
    'client_id' => env('MICROSOFT_CLIENT_ID'),
    'tenant'    => env('MICROSOFT_TENANT', 'common'),
],
```

The Google flow accepts `clientId` from the request body (matches the existing storefront pattern). Apple's `services.apple.client_id` is also read by the client side but is not required by the server-side `AppleVerifier`.

## Dependencies

No new deps. `google/apiclient` and `lcobucci/jwt` were already in `composer.json`.

## Test plan

- [x] `php -l` on all new and modified PHP files
- [x] `php artisan migrate` runs cleanly; `users.microsoft_user_id` lands with `varchar(255) UNIQUE`
- [x] All four routes are registered (verified via curl + `php artisan route:list`)
- [x] Each endpoint returns HTTP 400 with provider-specific `errors[0]` when posted a garbage token
- [x] Apple's malformed-JWT case returns 400, not 500 (regression caught and fixed during smoke)
- [x] Google end-to-end in browser with a real Google Cloud OAuth client — popup → ID token → server verification → Sanctum token → Console session
- [ ] Facebook / Office365 / Apple end-to-end (requires deployer to configure their own provider apps; backend smoke + code review proves correctness)

## Companion PR

Frontend UI: `fleetbase/fleetbase#TBD` (will link as soon as opened) — adds four conditional Sign-in-with-X buttons to `auth/login`, lazy-loads each provider's JS SDK, posts the resulting credential to the endpoints in this PR.

Refs: fleetbase/fleetbase#453