### PR TITLE
Add shared seed company resolver concern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.46",
+    "version": "1.6.47",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/seeders/Concerns/ResolvesSeedCompany.php
+++ b/seeders/Concerns/ResolvesSeedCompany.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Fleetbase\Seeders\Concerns;
+
+use Fleetbase\Models\Company;
+
+trait ResolvesSeedCompany
+{
+    protected function resolveSeedCompany(?string $fallbackUuidEnv = null, ?string $fallbackPublicIdEnv = null): ?Company
+    {
+        $companyUuid = env('SEED_COMPANY_UUID') ?: ($fallbackUuidEnv ? env($fallbackUuidEnv) : null);
+        $companyPublicId = env('SEED_COMPANY_PUBLIC_ID') ?: ($fallbackPublicIdEnv ? env($fallbackPublicIdEnv) : null);
+
+        if ($companyUuid) {
+            return Company::where('uuid', $companyUuid)->first();
+        }
+
+        if ($companyPublicId) {
+            return Company::where('public_id', $companyPublicId)->first();
+        }
+
+        return Company::query()->orderBy('created_at')->first();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Fleetbase\Seeders\Concerns\ResolvesSeedCompany for shared seeder company resolution.
- Supports SEED_COMPANY_UUID and SEED_COMPANY_PUBLIC_ID with seeder-specific fallback keys.

## Validation
- php -l seeders/Concerns/ResolvesSeedCompany.php