### PR TITLE
Fix resource lifecycle webhook payload mismatch

### DIFF
--- a/src/Listeners/SendResourceLifecycleWebhook.php
+++ b/src/Listeners/SendResourceLifecycleWebhook.php
@@ -37,12 +37,18 @@ class SendResourceLifecycleWebhook implements ShouldQueue
         $apiEnvironment  = session()->get('api_environment', $event->apiEnvironment ?? 'live');
         $isSandbox       = session()->get('is_sandbox', $event->isSandbox);
 
+        // Compute the event payload exactly once so the persisted ApiEvent record and the
+        // outbound webhook body are guaranteed to be identical. $event->getEventData() resolves
+        // the model live at handle time, whereas $event->data is a snapshot frozen at dispatch
+        // time; using each in a different place lets the DB record and the webhook diverge.
+        $payload = $event->getEventData();
+
         // Prepare event
         $eventData = [
             'company_uuid'        => $companyId,
             'event'               => $event->broadcastAs(),
             'source'              => $apiCredentialId ? 'api' : 'console',
-            'data'                => $event->getEventData(),
+            'data'                => $payload,
             'method'              => $event->requestMethod,
             'description'         => $this->getHumanReadableEventDescription($event),
         ];
@@ -100,7 +106,7 @@ class SendResourceLifecycleWebhook implements ShouldQueue
                         'sent_at'             => Carbon::now(),
                     ])
                     ->url($webhook->url)
-                    ->payload($event->data)
+                    ->payload($payload)
                     ->useSecret($apiSecret)
                     ->dispatch();
             } catch (\Exception|\Aws\Sqs\Exception\SqsException $exception) {


### PR DESCRIPTION
## Summary

This PR fixes a payload mismatch in `SendResourceLifecycleWebhook`.

Previously, the listener stored the API event using `$event->getEventData()`, but sent the webhook using `$event->data`. Because these values can be resolved at different times, the payload stored in `api_events.data` could differ from the payload actually sent to integrators.

This change computes the lifecycle payload once and reuses it for both the stored `ApiEvent` record and the outbound webhook request body.

## Background

For `order.completed` webhooks, we observed cases where the payload recorded in the database did not match the payload sent to the webhook endpoint. This made it difficult to rely on `api_events.data` as an accurate record of delivered webhook data.

## Changes

* Compute `$payload = $event->getEventData()` once in `SendResourceLifecycleWebhook`
* Store `$payload` in `api_events.data`
* Send `$payload` as the outbound webhook body

## Related PRs

* fleetbase/fleetops#258
