### PR TITLE
Update Fleetbase blog RSS source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.51",
+    "version": "1.6.52",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/src/Support/FleetbaseBlog.php
+++ b/src/Support/FleetbaseBlog.php
@@ -62,7 +62,7 @@ class FleetbaseBlog
         $host = parse_url($link, PHP_URL_HOST);
         $path = trim((string) parse_url($link, PHP_URL_PATH), '/');
 
-        if ($host && Str::contains($host, 'ghost.io') && $path) {
+        if ($host && (Str::contains($host, 'ghost.io') || $host === 'blog.fleetbase.io') && $path) {
             return $blogUrl . '/' . $path;
         }
 
@@ -74,7 +74,7 @@ class FleetbaseBlog
      */
     public static function getFeedUrl(?string $feedUrl = null): string
     {
-        return rtrim($feedUrl ?: getenv('FLEETBASE_BLOG_FEED_URL') ?: 'https://fleetbase.ghost.io/rss/', '/') . '/';
+        return rtrim($feedUrl ?: getenv('FLEETBASE_BLOG_FEED_URL') ?: 'https://blog.fleetbase.io/rss/', '/') . '/';
     }
 
     /**

--- a/tests/Unit/FleetbaseBlogTest.php
+++ b/tests/Unit/FleetbaseBlogTest.php
@@ -11,7 +11,7 @@ function fleetbaseBlogRssFixture(): string
     <item>
       <title><![CDATA[First Ghost Post]]></title>
       <description><![CDATA[<p>First excerpt.</p>]]></description>
-      <link>https://fleetbase.ghost.io/first-ghost-post/</link>
+      <link>https://blog.fleetbase.io/first-ghost-post/</link>
       <guid isPermaLink="false">ghost-post-1</guid>
       <dc:creator><![CDATA[Fleetbase Team]]></dc:creator>
       <pubDate>Wed, 06 May 2026 14:31:46 GMT</pubDate>
@@ -21,7 +21,7 @@ function fleetbaseBlogRssFixture(): string
     <item>
       <title><![CDATA[Second Ghost Post]]></title>
       <description><![CDATA[<p>Second excerpt.</p>]]></description>
-      <link>https://fleetbase.ghost.io/second-ghost-post/</link>
+      <link>https://blog.fleetbase.io/second-ghost-post/</link>
       <guid isPermaLink="false">ghost-post-2</guid>
       <dc:creator><![CDATA[Fleetbase Team]]></dc:creator>
       <pubDate>Wed, 06 May 2026 14:30:46 GMT</pubDate>
@@ -63,5 +63,6 @@ test('fleetbase blog parser returns an empty array for malformed rss', function 
 
 test('fleetbase blog link normalization keeps non ghost links unchanged', function () {
     expect(FleetbaseBlog::normalizeLink('https://www.fleetbase.io/blog/already-canonical'))->toBe('https://www.fleetbase.io/blog/already-canonical')
-        ->and(FleetbaseBlog::normalizeLink('https://fleetbase.ghost.io/ghost-post/'))->toBe('https://www.fleetbase.io/blog/ghost-post');
+        ->and(FleetbaseBlog::normalizeLink('https://fleetbase.ghost.io/legacy-ghost-post/'))->toBe('https://www.fleetbase.io/blog/legacy-ghost-post')
+        ->and(FleetbaseBlog::normalizeLink('https://blog.fleetbase.io/ghost-post/'))->toBe('https://www.fleetbase.io/blog/ghost-post');
 });


### PR DESCRIPTION
## Summary
- Update the default Fleetbase blog RSS feed source to the self-hosted blog host.
- Normalize self-hosted blog post links back to canonical fleetbase.io blog URLs.
- Refresh unit fixtures to cover the self-hosted blog RSS link shape while preserving legacy Ghost normalization.

## Verification
- ./vendor/bin/pest tests/Unit/FleetbaseBlogTest.php