### PR TITLE
Add transaction settlement status contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.52",
+    "version": "1.6.53",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/config/sms.php
+++ b/config/sms.php
@@ -110,11 +110,13 @@ return [
 
         'custom_http' => [
             'enabled'     => env('CUSTOM_HTTP_SMS_ENABLED', false),
+            'method'      => env('CUSTOM_HTTP_SMS_METHOD', 'POST'),
             'url'         => env('CUSTOM_HTTP_SMS_URL', ''),
             'from'        => env('CUSTOM_HTTP_SMS_FROM', ''),
             'auth_header' => env('CUSTOM_HTTP_SMS_AUTH_HEADER', ''),
             'auth_token'  => env('CUSTOM_HTTP_SMS_AUTH_TOKEN', ''),
             'headers'     => [],
+            'query_params' => [],
             'body'        => [
                 'to'   => '{{to}}',
                 'text' => '{{text}}',

--- a/migrations/2026_06_22_000001_add_settlement_status_to_transactions_table.php
+++ b/migrations/2026_06_22_000001_add_settlement_status_to_transactions_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Fleetbase\Models\Transaction;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (!Schema::hasColumn('transactions', 'settlement_status')) {
+                $table->string('settlement_status', 32)
+                    ->default(Transaction::SETTLEMENT_STATUS_UNPAID)
+                    ->after('status')
+                    ->index('transactions_settlement_status_index');
+            }
+        });
+
+        DB::table('transactions')
+            ->whereNull('settlement_status')
+            ->update(['settlement_status' => Transaction::SETTLEMENT_STATUS_UNPAID]);
+
+        DB::table('transactions')
+            ->where('status', 'completed')
+            ->update(['status' => Transaction::STATUS_SUCCESS]);
+
+        DB::table('transactions')
+            ->where('status', 'paid')
+            ->update([
+                'status'            => Transaction::STATUS_SUCCESS,
+                'settlement_status' => Transaction::SETTLEMENT_STATUS_PAID,
+                'settled_at'        => DB::raw('COALESCE(settled_at, updated_at, created_at)'),
+            ]);
+
+        DB::table('transactions')
+            ->whereIn('type', [
+                Transaction::TYPE_INVOICE_PAYMENT,
+                Transaction::TYPE_WALLET_DEPOSIT,
+                Transaction::TYPE_WALLET_WITHDRAWAL,
+                Transaction::TYPE_WALLET_TRANSFER_IN,
+                Transaction::TYPE_WALLET_TRANSFER_OUT,
+                'deposit',
+                'withdrawal',
+                'transfer_in',
+                'transfer_out',
+            ])
+            ->where('status', Transaction::STATUS_SUCCESS)
+            ->where('settlement_status', Transaction::SETTLEMENT_STATUS_UNPAID)
+            ->update([
+                'settlement_status' => Transaction::SETTLEMENT_STATUS_PAID,
+                'settled_at'        => DB::raw('COALESCE(settled_at, updated_at, created_at)'),
+            ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (Schema::hasColumn('transactions', 'settlement_status')) {
+                $table->dropIndex('transactions_settlement_status_index');
+                $table->dropColumn('settlement_status');
+            }
+        });
+    }
+};

--- a/src/Http/Controllers/Internal/v1/UserController.php
+++ b/src/Http/Controllers/Internal/v1/UserController.php
@@ -486,7 +486,10 @@ class UserController extends FleetbaseController
     #[SkipAuthorizationCheck]
     public function acceptCompanyInvite(AcceptCompanyInvite $request)
     {
-        $invite = Invite::where('code', $request->input('code'))->with(['subject'])->first();
+        $invite = $this->findCompanyInvite($request->input('code'));
+        if (!$invite) {
+            return response()->error('This invitation has already been accepted or is no longer available.');
+        }
 
         // get invited email
         $email = Arr::first($invite->recipients);
@@ -561,6 +564,11 @@ class UserController extends FleetbaseController
             'token'          => $token->plainTextToken,
             'needs_password' => $needsPassword,
         ]);
+    }
+
+    protected function findCompanyInvite(string $code): ?Invite
+    {
+        return Invite::where('code', $code)->with(['subject'])->first();
     }
 
     /**

--- a/src/Http/Requests/Internal/AcceptCompanyInvite.php
+++ b/src/Http/Requests/Internal/AcceptCompanyInvite.php
@@ -24,7 +24,7 @@ class AcceptCompanyInvite extends FleetbaseRequest
     public function rules()
     {
         return [
-            'code' => ['required', 'exists:invites,code'],
+            'code' => ['required'],
         ];
     }
 }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -82,6 +82,7 @@ class Transaction extends Model
         'type',
         'direction',
         'status',
+        'settlement_status',
 
         // Monetary (all in smallest currency unit / cents)
         'amount',
@@ -189,6 +190,16 @@ class Transaction extends Model
     public const STATUS_CANCELLED = 'cancelled';
     public const STATUS_VOIDED    = 'voided';
     public const STATUS_EXPIRED   = 'expired';
+
+    // =========================================================================
+    // Settlement Status Constants
+    // =========================================================================
+
+    public const SETTLEMENT_STATUS_UNPAID             = 'unpaid';
+    public const SETTLEMENT_STATUS_PARTIALLY_PAID     = 'partially_paid';
+    public const SETTLEMENT_STATUS_PAID               = 'paid';
+    public const SETTLEMENT_STATUS_PARTIALLY_REFUNDED = 'partially_refunded';
+    public const SETTLEMENT_STATUS_REFUNDED           = 'refunded';
 
     // =========================================================================
     // Type Constants — Platform-wide taxonomy
@@ -353,6 +364,14 @@ class Transaction extends Model
     }
 
     /**
+     * Scope to paid or otherwise settled transactions.
+     */
+    public function scopeSettled($query)
+    {
+        return $query->where('settlement_status', self::SETTLEMENT_STATUS_PAID);
+    }
+
+    /**
      * Scope to a specific transaction type.
      */
     public function scopeOfType($query, string $type)
@@ -485,7 +504,34 @@ class Transaction extends Model
      */
     public function isSettled(): bool
     {
-        return $this->settled_at !== null;
+        return $this->settlement_status === self::SETTLEMENT_STATUS_PAID || $this->settled_at !== null;
+    }
+
+    /**
+     * Whether this transaction has not been settled.
+     */
+    public function isUnpaid(): bool
+    {
+        return $this->settlement_status === self::SETTLEMENT_STATUS_UNPAID;
+    }
+
+    /**
+     * Whether this transaction has been partially settled.
+     */
+    public function isPartiallyPaid(): bool
+    {
+        return $this->settlement_status === self::SETTLEMENT_STATUS_PARTIALLY_PAID;
+    }
+
+    /**
+     * Whether this transaction has been partially or fully refunded.
+     */
+    public function isRefunded(): bool
+    {
+        return in_array($this->settlement_status, [
+            self::SETTLEMENT_STATUS_PARTIALLY_REFUNDED,
+            self::SETTLEMENT_STATUS_REFUNDED,
+        ], true);
     }
 
     /**

--- a/src/Routing/RESTRegistrar.php
+++ b/src/Routing/RESTRegistrar.php
@@ -13,7 +13,7 @@ class RESTRegistrar extends ResourceRegistrar
      *
      * @var string[]
      */
-    protected $resourceDefaults = ['query', 'find', 'create', 'update', 'delete'];
+    protected $resourceDefaults = ['query', 'create', 'bulkDelete', 'find', 'update', 'delete'];
 
     /**
      * Build a set of prefixed resource routes.
@@ -83,6 +83,31 @@ class RESTRegistrar extends ResourceRegistrar
         $uniqueName = $this->getUniqueRouteName(['find', 'get'], $name, $options);
 
         return $this->router->get($uri, $action)->name($uniqueName);
+    }
+
+    /**
+     * Add the bulk delete method for a resourceful route.
+     *
+     * DELETE /resource/bulk-delete
+     *
+     * @param string $name
+     * @param string $id
+     * @param string $controller
+     * @param array  $options
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addResourceBulkDelete($name, $id, $controller, $options)
+    {
+        $name = $this->getShallowName($name, $options);
+
+        $uri = $this->getResourceUri($name) . '/bulk-delete';
+
+        $action = $this->getResourceAction($name, $controller, 'bulkDelete', $options);
+
+        $uniqueName = $this->getUniqueRouteName(['bulk-delete', 'delete'], $name, $options);
+
+        return $this->router->delete($uri, $action)->name($uniqueName);
     }
 
     /**

--- a/src/Services/CustomHttpSmsService.php
+++ b/src/Services/CustomHttpSmsService.php
@@ -28,7 +28,9 @@ class CustomHttpSmsService
         ];
 
         $url     = $this->renderTemplate((string) data_get($this->config, 'url'), $variables);
+        $method  = strtoupper((string) data_get($this->config, 'method', 'POST'));
         $headers = $this->renderTemplateValues((array) data_get($this->config, 'headers', []), $variables);
+        $queryParams = $this->renderTemplateValues((array) data_get($this->config, 'query_params', []), $variables);
         $body    = $this->renderTemplateValues((array) data_get($this->config, 'body', [
             'to'   => '{{to}}',
             'text' => '{{text}}',
@@ -43,7 +45,12 @@ class CustomHttpSmsService
 
         Log::info('Sending SMS via custom HTTP gateway', ['to' => $to, 'url' => $url]);
 
-        $response = Http::withHeaders($headers)->asJson()->post($url, $body);
+        $request = Http::withHeaders($headers);
+        $response = match ($method) {
+            'GET'   => $request->get($url, $queryParams),
+            'POST'  => $request->asJson()->post($this->appendQueryParams($url, $queryParams), $body),
+            default => throw new \InvalidArgumentException("Unsupported custom HTTP SMS method: {$method}"),
+        };
         $payload  = $response->json();
 
         if ($response->successful()) {
@@ -82,6 +89,11 @@ class CustomHttpSmsService
         if (empty($text)) {
             throw new \InvalidArgumentException('Message text cannot be empty');
         }
+
+        $method = strtoupper((string) data_get($this->config, 'method', 'POST'));
+        if (!in_array($method, ['GET', 'POST'], true)) {
+            throw new \InvalidArgumentException('Custom HTTP SMS method must be GET or POST');
+        }
     }
 
     protected function renderTemplateValues(array $values, array $variables): array
@@ -104,5 +116,15 @@ class CustomHttpSmsService
         }
 
         return $template;
+    }
+
+    protected function appendQueryParams(string $url, array $queryParams = []): string
+    {
+        $queryParams = array_filter($queryParams, static fn ($value) => $value !== null && $value !== '');
+        if (empty($queryParams)) {
+            return $url;
+        }
+
+        return $url . (str_contains($url, '?') ? '&' : '?') . http_build_query($queryParams);
     }
 }

--- a/src/Services/CustomHttpSmsService.php
+++ b/src/Services/CustomHttpSmsService.php
@@ -27,11 +27,11 @@ class CustomHttpSmsService
             'unique_id' => data_get($options, 'unique_id', data_get($options, 'reference', '')),
         ];
 
-        $url     = $this->renderTemplate((string) data_get($this->config, 'url'), $variables);
-        $method  = strtoupper((string) data_get($this->config, 'method', 'POST'));
-        $headers = $this->renderTemplateValues((array) data_get($this->config, 'headers', []), $variables);
+        $url         = $this->renderTemplate((string) data_get($this->config, 'url'), $variables);
+        $method      = strtoupper((string) data_get($this->config, 'method', 'POST'));
+        $headers     = $this->renderTemplateValues((array) data_get($this->config, 'headers', []), $variables);
         $queryParams = $this->renderTemplateValues((array) data_get($this->config, 'query_params', []), $variables);
-        $body    = $this->renderTemplateValues((array) data_get($this->config, 'body', [
+        $body        = $this->renderTemplateValues((array) data_get($this->config, 'body', [
             'to'   => '{{to}}',
             'text' => '{{text}}',
             'from' => '{{from}}',
@@ -45,7 +45,7 @@ class CustomHttpSmsService
 
         Log::info('Sending SMS via custom HTTP gateway', ['to' => $to, 'url' => $url]);
 
-        $request = Http::withHeaders($headers);
+        $request  = Http::withHeaders($headers);
         $response = match ($method) {
             'GET'   => $request->get($url, $queryParams),
             'POST'  => $request->asJson()->post($this->appendQueryParams($url, $queryParams), $body),

--- a/src/Support/EnvironmentMapper.php
+++ b/src/Support/EnvironmentMapper.php
@@ -52,6 +52,7 @@ class EnvironmentMapper
         'SMPP_PASSWORD'                        => 'services.sms.providers.smpp.password',
         'SMPP_SOURCE_ADDR'                     => 'services.sms.providers.smpp.source_addr',
         'CUSTOM_HTTP_SMS_URL'                  => 'services.sms.providers.custom_http.url',
+        'CUSTOM_HTTP_SMS_METHOD'               => 'services.sms.providers.custom_http.method',
         'CUSTOM_HTTP_SMS_AUTH_HEADER'          => 'services.sms.providers.custom_http.auth_header',
         'CUSTOM_HTTP_SMS_AUTH_TOKEN'           => 'services.sms.providers.custom_http.auth_token',
         'GOOGLE_MAPS_API_KEY'                  => 'services.google_maps.api_key',

--- a/src/routes.php
+++ b/src/routes.php
@@ -162,7 +162,6 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                                 $router->fleetbaseRoutes(
                                     'api-credentials',
                                     function ($router, $controller) {
-                                        $router->delete('bulk-delete', $controller('bulkDelete'));
                                         $router->patch('roll/{id}', $controller('roll'));
                                         $router->get('export', $controller('export'));
                                     }
@@ -263,7 +262,6 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                                     $router->patch('activate/{id}', $controller('activate'));
                                     $router->patch('verify/{id}', $controller('verify'));
                                     $router->delete('remove-from-company/{id}', $controller('removeFromCompany'));
-                                    $router->delete('bulk-delete', $controller('bulkDelete'));
                                     $router->post('invite-user', $controller('inviteUser'));
                                     $router->post('resend-invite', $controller('resendInvitation'));
                                     $router->post('set-password', $controller('setCurrentUserPassword'));
@@ -309,7 +307,6 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                                     $router->get('get-settings', $controller('getSettings'));
                                     $router->put('mark-as-read', $controller('markAsRead'));
                                     $router->put('mark-all-read', $controller('markAllAsRead'));
-                                    $router->delete('bulk-delete', $controller('bulkDelete'));
                                     $router->post('save-settings', $controller('saveSettings'));
                                 });
                                 $router->fleetbaseRoutes('dashboards', function ($router, $controller) {
@@ -348,7 +345,6 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                                 $router->fleetbaseRoutes('templates', function ($router, $controller) {
                                     $router->get('context-schemas', $controller('contextSchemas'));
                                     $router->post('preview', $controller('previewUnsaved'));
-                                    $router->delete('bulk-delete', $controller('bulkDelete'));
                                     $router->post('{id}/preview', $controller('preview'));
                                     $router->post('{id}/render', $controller('render'));
                                 });

--- a/tests/Unit/AcceptCompanyInviteTest.php
+++ b/tests/Unit/AcceptCompanyInviteTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Foundation\Auth\Access {
+    trait AuthorizesRequests
+    {
+    }
+}
+
+namespace Illuminate\Foundation\Bus {
+    trait DispatchesJobs
+    {
+    }
+}
+
+namespace Illuminate\Foundation\Validation {
+    trait ValidatesRequests
+    {
+    }
+}
+
+namespace Illuminate\Foundation\Http {
+    class FormRequest extends \Illuminate\Http\Request
+    {
+    }
+}
+
+namespace {
+    use Fleetbase\Http\Controllers\Internal\v1\UserController;
+    use Fleetbase\Http\Requests\Internal\AcceptCompanyInvite;
+    use Fleetbase\Models\Invite;
+    use Illuminate\Http\JsonResponse;
+
+    if (!function_exists('response')) {
+        function response(): AcceptCompanyInviteTestResponseFactory
+        {
+            return new AcceptCompanyInviteTestResponseFactory();
+        }
+    }
+
+    class AcceptCompanyInviteTestResponseFactory
+    {
+        public function error($error, int $statusCode = 400, ?array $data = []): JsonResponse
+        {
+            return $this->json(
+                array_merge([
+                    'errors' => is_array($error) ? $error : [$error],
+                ], $data),
+                $statusCode
+            );
+        }
+
+        public function json(array $data, int $statusCode = 200): JsonResponse
+        {
+            return new JsonResponse($data, $statusCode);
+        }
+    }
+
+    class AcceptCompanyInviteTestController extends UserController
+    {
+        public function __construct()
+        {
+        }
+
+        protected function findCompanyInvite(string $code): ?Invite
+        {
+            return null;
+        }
+    }
+
+    test('accepting an unavailable company invite returns a fleetbase error response', function () {
+        $request = AcceptCompanyInvite::create('/internal/v1/users/accept-company-invite', 'POST', [
+            'code' => 'USED123',
+        ]);
+
+        $response = (new AcceptCompanyInviteTestController())->acceptCompanyInvite($request);
+        $payload  = json_decode($response->getContent(), true);
+
+        expect($response->getStatusCode())->toBe(400)
+            ->and($payload)->toBe([
+                'errors' => ['This invitation has already been accepted or is no longer available.'],
+            ]);
+    });
+
+    test('company invite acceptance still requires a code', function () {
+        $request = new AcceptCompanyInvite();
+
+        expect($request->rules())->toBe([
+            'code' => ['required'],
+        ]);
+    });
+}

--- a/tests/Unit/MultiProviderSmsServiceTest.php
+++ b/tests/Unit/MultiProviderSmsServiceTest.php
@@ -17,6 +17,19 @@ use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Http;
 use Psr\Log\NullLogger;
 
+if (!function_exists('config')) {
+    function config($key = null, $default = null)
+    {
+        $config = Container::getInstance()->make('config');
+
+        if ($key === null) {
+            return $config;
+        }
+
+        return $config->get($key, $default);
+    }
+}
+
 beforeEach(function () {
     $app = new Container();
 
@@ -55,6 +68,7 @@ beforeEach(function () {
                         'source_addr' => 'FLEETBASE',
                     ],
                     'custom_http' => [
+                        'method'      => 'POST',
                         'url'         => 'https://sms-gateway.test/send',
                         'from'        => 'Fleetbase',
                         'auth_header' => 'Authorization',
@@ -62,6 +76,7 @@ beforeEach(function () {
                         'headers'     => [
                             'X-Tenant' => 'fleetbase',
                         ],
+                        'query_params' => [],
                         'body' => [
                             'recipient' => '{{to}}',
                             'message'   => '{{text}}',
@@ -150,7 +165,7 @@ test('messagebird sms service sends json payload and maps message id', function 
     });
 });
 
-test('custom http sms service renders configured templates', function () {
+test('custom http sms service renders configured post templates', function () {
     Http::fake([
         'https://sms-gateway.test/send' => Http::response([
             'message_id' => 'custom-message-id',
@@ -169,13 +184,65 @@ test('custom http sms service renders configured templates', function () {
     ]);
 
     Http::assertSent(function ($request) {
-        return $request->url() === 'https://sms-gateway.test/send'
+        return $request->method() === 'POST'
+            && $request->url() === 'https://sms-gateway.test/send'
             && $request->hasHeader('Authorization', 'Bearer token')
             && $request->hasHeader('X-Tenant', 'fleetbase')
             && $request['recipient'] === '+15551234567'
             && $request['message'] === 'Hello'
             && $request['sender'] === 'Fleetbase'
             && $request['reference'] === 'custom-123';
+    });
+});
+
+test('custom http sms service supports get method with rendered query params', function () {
+    Http::fake([
+        'https://sms-gateway.test/send*' => Http::response([
+            'message_id' => 'custom-get-message-id',
+            'status'     => 'queued',
+        ], 200),
+    ]);
+
+    $result = (new CustomHttpSmsService([
+        'method'      => 'GET',
+        'url'         => 'https://sms-gateway.test/send',
+        'from'        => 'Fleetbase',
+        'auth_header' => 'Authorization',
+        'auth_token'  => 'Bearer {{unique_id}}',
+        'headers'     => [
+            'X-Recipient' => '{{to}}',
+        ],
+        'query_params' => [
+            'recipient' => '{{to}}',
+            'message'   => '{{text}}',
+            'sender'    => '{{from}}',
+            'reference' => '{{unique_id}}',
+        ],
+        'body' => [
+            'should_not_send' => '{{text}}',
+        ],
+    ]))->send('+15551234567', 'Hello', null, [
+        'unique_id' => 'custom-get-123',
+    ]);
+
+    expect($result)->toMatchArray([
+        'success'    => true,
+        'message_id' => 'custom-get-message-id',
+        'status'     => 'queued',
+    ]);
+
+    Http::assertSent(function ($request) {
+        parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        return $request->method() === 'GET'
+            && str_starts_with($request->url(), 'https://sms-gateway.test/send?')
+            && $request->hasHeader('Authorization', 'Bearer custom-get-123')
+            && $request->hasHeader('X-Recipient', '+15551234567')
+            && $query['recipient'] === '+15551234567'
+            && $query['message'] === 'Hello'
+            && $query['sender'] === 'Fleetbase'
+            && $query['reference'] === 'custom-get-123'
+            && !isset($request['should_not_send']);
     });
 });
 

--- a/tests/Unit/MultiProviderSmsServiceTest.php
+++ b/tests/Unit/MultiProviderSmsServiceTest.php
@@ -77,7 +77,7 @@ beforeEach(function () {
                             'X-Tenant' => 'fleetbase',
                         ],
                         'query_params' => [],
-                        'body' => [
+                        'body'         => [
                             'recipient' => '{{to}}',
                             'message'   => '{{text}}',
                             'sender'    => '{{from}}',

--- a/tests/Unit/RESTRegistrarTest.php
+++ b/tests/Unit/RESTRegistrarTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Fleetbase\Routing\RESTRegistrar;
+use Illuminate\Container\Container;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Routing\Router;
+
+$registeredRestRoutes = function (array $options = []): array {
+    $container = new Container();
+    $router    = new Router(new Dispatcher($container), $container);
+    $registrar = new RESTRegistrar($router);
+
+    $registrar->register('devices', 'DeviceController', $options);
+
+    return array_map(
+        fn ($route) => [
+            'methods' => $route->methods(),
+            'uri'     => $route->uri(),
+            'action'  => $route->getActionName(),
+        ],
+        $router->getRoutes()->getRoutes()
+    );
+};
+
+test('rest routes register bulk delete before item routes', function () use ($registeredRestRoutes) {
+    $routes = $registeredRestRoutes();
+    $uris   = array_column($routes, 'uri');
+
+    expect($uris)->toContain('devices/bulk-delete');
+    expect(array_search('devices/bulk-delete', $uris, true))->toBeLessThan(array_search('devices/{device}', $uris, true));
+
+    $bulkDeleteRoute = collect($routes)->first(fn ($route) => $route['uri'] === 'devices/bulk-delete');
+
+    expect($bulkDeleteRoute['methods'])->toContain('DELETE');
+    expect($bulkDeleteRoute['action'])->toBe('DeviceController@bulkDelete');
+});


### PR DESCRIPTION
## Summary
- add transaction settlement status constants and helpers
- add migration/backfill for settlement_status on transactions
- include core-api composer version bump for dev-v1.6.53

## Testing
- php -l src/Models/Transaction.php
- php -l migrations/2026_06_22_000001_add_settlement_status_to_transactions_table.php