### PR TITLE
Fix dynamic request resolution

### DIFF
--- a/src/Support/Find.php
+++ b/src/Support/Find.php
@@ -106,7 +106,7 @@ class Find
         }
 
         if ($requestNamespace === null) {
-            $requestNamespace = $requestNS . '\\' . Str::studly(ucfirst(Http::action()) . ucfirst($modelName) . 'Request');
+            $requestNamespace = $requestNS . Str::studly(ucfirst(Http::action()) . ucfirst($modelName) . 'Request');
         }
 
         if (!Utils::classExists($requestNamespace)) {

--- a/tests/Fixtures/Http/Requests/CreateAssetValidationRecordRequest.php
+++ b/tests/Fixtures/Http/Requests/CreateAssetValidationRecordRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Fleetbase\Tests\Fixtures\Http\Requests;
+
+class CreateAssetValidationRecordRequest
+{
+    public function authorize()
+    {
+        return false;
+    }
+
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/tests/Fixtures/Http/Requests/UpdateAssetValidationRecordRequest.php
+++ b/tests/Fixtures/Http/Requests/UpdateAssetValidationRecordRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Fleetbase\Tests\Fixtures\Http\Requests;
+
+class UpdateAssetValidationRecordRequest extends CreateAssetValidationRecordRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'name' => ['sometimes', 'nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/tests/Fixtures/Models/AssetValidationRecord.php
+++ b/tests/Fixtures/Models/AssetValidationRecord.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Fleetbase\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AssetValidationRecord extends Model
+{
+}

--- a/tests/Fixtures/Models/MissingRequestRecord.php
+++ b/tests/Fixtures/Models/MissingRequestRecord.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Fleetbase\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MissingRequestRecord extends Model
+{
+}

--- a/tests/Unit/FindHttpRequestForModelTest.php
+++ b/tests/Unit/FindHttpRequestForModelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Fleetbase\Support {
+    if (!function_exists('Fleetbase\Support\request')) {
+        function request()
+        {
+            return new class {
+                public function route()
+                {
+                    return null;
+                }
+            };
+        }
+    }
+}
+
+namespace {
+    use Fleetbase\Http\Requests\FleetbaseRequest;
+    use Fleetbase\Support\Find;
+    use Fleetbase\Tests\Fixtures\Http\Requests\CreateAssetValidationRecordRequest;
+    use Fleetbase\Tests\Fixtures\Http\Requests\UpdateAssetValidationRecordRequest;
+    use Fleetbase\Tests\Fixtures\Models\AssetValidationRecord;
+    use Fleetbase\Tests\Fixtures\Models\MissingRequestRecord;
+
+    beforeEach(function () {
+        unset($_SERVER['REQUEST_METHOD']);
+    });
+
+    test('resolves create request class for a model without duplicating namespace separators', function () {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $requestClass = Find::httpRequestForModel(new AssetValidationRecord(), '\Fleetbase\Tests\Fixtures');
+
+        expect($requestClass)
+            ->toBe('\\' . CreateAssetValidationRecordRequest::class)
+            ->not->toContain('\\\\CreateAssetValidationRecordRequest');
+    });
+
+    test('resolves update request class for a model without duplicating namespace separators', function () {
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $requestClass = Find::httpRequestForModel(new AssetValidationRecord(), '\Fleetbase\Tests\Fixtures');
+
+        expect($requestClass)
+            ->toBe('\\' . UpdateAssetValidationRecordRequest::class)
+            ->not->toContain('\\\\UpdateAssetValidationRecordRequest');
+    });
+
+    test('falls back to fleetbase request when no model request exists', function () {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        expect(Find::httpRequestForModel(new MissingRequestRecord(), '\Fleetbase\Tests\Fixtures'))
+            ->toBe('\\' . FleetbaseRequest::class);
+    });
+}


### PR DESCRIPTION
## Summary

- Fix dynamic FormRequest resolution for CRUD models by avoiding a duplicated namespace separator.
- Add regression coverage for create/update request resolution and the FleetbaseRequest fallback path.

## Root cause

`Find::httpRequestForModel()` built action-specific request class names by appending an extra namespace separator even though the request namespace already ended with one. That produced malformed class names such as `...\Http\Requests\\UpdateAssetRequest`, causing class lookup to fail and validation to fall back to the generic Fleetbase request.

## Validation

- `./vendor/bin/pest tests/Unit/FindHttpRequestForModelTest.php --colors=always`
- `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff src/Support/Find.php tests/Unit/FindHttpRequestForModelTest.php tests/Fixtures/Models/AssetValidationRecord.php tests/Fixtures/Models/MissingRequestRecord.php tests/Fixtures/Http/Requests/CreateAssetValidationRecordRequest.php tests/Fixtures/Http/Requests/UpdateAssetValidationRecordRequest.php`

`composer test:unit` is still blocked by the existing missing `Tests\TestCase` issue in `tests/Unit/Reporting/ComputedColumnValidatorTest.php`.
