### PR TITLE
Fix security advisory issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -38,7 +38,7 @@ jobs:
       run: composer install --prefer-dist --no-progress
 
     - name: Run Lint
-      run: composer lint
+      run: composer test:lint
 
-    # - name: Run Tests -- Will add tests back after phppest issue https://github.com/pestphp/pest/issues/920 is fixed
-    #   run: composer test:unit
+    - name: Run Tests
+      run: composer test:unit

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
     "scripts": {
         "lint": "php-cs-fixer fix -v",
         "test:lint": "php-cs-fixer fix -v --dry-run",
-        "test:types": "phpstan analyse --ansi --memory-limit=0",
+        "test:types": "phpstan analyse --ansi --memory-limit=-1",
         "test:unit": "pest --colors=always",
         "test": [
             "@test:lint",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "rlanvin/php-rrule": "^2.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.34.1",
+        "friendsofphp/php-cs-fixer": "3.82.2",
         "nunomaduro/collision": "^7.0",
         "pestphp/pest": "^2.33.2",
         "phpstan/phpstan": "^1.10.38",

--- a/config/fleetbase.php
+++ b/config/fleetbase.php
@@ -55,5 +55,8 @@ return [
         'enabled' => env('USER_CACHE_ENABLED', true),
         'server_ttl' => (int) env('USER_CACHE_SERVER_TTL', 900), // 15 minutes
         'browser_ttl' => (int) env('USER_CACHE_BROWSER_TTL', 300), // 5 minutes
-    ]
+    ],
+
+    'template_query_models'        => [],
+    'template_global_query_models' => [],
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          colors="true"
+         cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="default">
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Auth/Schemas/IAM.php
+++ b/src/Auth/Schemas/IAM.php
@@ -34,7 +34,7 @@ class IAM
         ],
         [
             'name'    => 'user',
-            'actions' => ['deactivate', 'activate', 'verify', 'export', 'change-password-for'],
+            'actions' => ['deactivate', 'activate', 'verify', 'export', 'change-password-for', 'change-email-for'],
         ],
         [
             'name'    => 'role',

--- a/src/Expansions/Route.php
+++ b/src/Expansions/Route.php
@@ -128,6 +128,7 @@ class Route implements Expansion
                     $router->post('logout', [$authControllerClass, 'logout']);
                     $router->post('get-magic-reset-link', [$authControllerClass, 'createPasswordReset']);
                     $router->post('reset-password', [$authControllerClass, 'resetPassword']);
+                    $router->post('confirm-email-change', [$authControllerClass, 'confirmEmailChange']);
                     $router->post('create-verification-session', [$authControllerClass, 'createVerificationSession']);
                     $router->post('validate-verification-session', [$authControllerClass, 'validateVerificationSession']);
                     $router->post('send-verification-email', [$authControllerClass, 'sendVerificationEmail']);

--- a/src/Http/Controllers/Api/v1/OrganizationController.php
+++ b/src/Http/Controllers/Api/v1/OrganizationController.php
@@ -12,6 +12,26 @@ use Laravel\Sanctum\PersonalAccessToken;
 
 class OrganizationController extends Controller
 {
+    public function listOrganizations(Request $request)
+    {
+        $limit = max(1, min((int) $request->input('limit', 10), 100));
+
+        $organizations = Company::query()
+            ->select(['name', 'public_id'])
+            ->whereHas('users')
+            ->limit($limit)
+            ->get()
+            ->map(function (Company $company) {
+                return [
+                    'name'      => $company->name,
+                    'public_id' => $company->public_id,
+                ];
+            })
+            ->values();
+
+        return response()->json($organizations);
+    }
+
     public function getCurrent(Request $request)
     {
         $token       = $request->bearerToken();

--- a/src/Http/Controllers/Api/v1/OrganizationController.php
+++ b/src/Http/Controllers/Api/v1/OrganizationController.php
@@ -14,11 +14,15 @@ class OrganizationController extends Controller
 {
     public function listOrganizations(Request $request)
     {
-        $limit = max(1, min((int) $request->input('limit', 10), 100));
+        $limit       = max(1, min((int) $request->input('limit', 10), 100));
+        $searchQuery = trim((string) $request->input('query', ''));
 
         $organizations = Company::query()
             ->select(['name', 'public_id'])
             ->whereHas('users')
+            ->when($searchQuery !== '', function ($query) use ($searchQuery) {
+                $query->where('companies.name', 'LIKE', '%' . $searchQuery . '%');
+            })
             ->limit($limit)
             ->get()
             ->map(function (Company $company) {

--- a/src/Http/Controllers/Internal/v1/ApiCredentialController.php
+++ b/src/Http/Controllers/Internal/v1/ApiCredentialController.php
@@ -182,7 +182,9 @@ class ApiCredentialController extends FleetbaseController
         }
 
         // get the api key to roll
-        $apiCredential = ApiCredential::find($id);
+        $apiCredential = ApiCredential::where('uuid', $id)
+            ->where('company_uuid', session('company'))
+            ->first();
 
         // if no api key respond with error
         if (!$apiCredential) {

--- a/src/Http/Controllers/Internal/v1/AuthController.php
+++ b/src/Http/Controllers/Internal/v1/AuthController.php
@@ -564,8 +564,21 @@ class AuthController extends Controller
      */
     public function createPasswordReset(UserForgotPasswordRequest $request)
     {
-        $email = strtolower((string) $request->input('email'));
-        $user  = User::where('email', $email)->first();
+        $email    = strtolower(trim((string) $request->input('email')));
+        $response = ['status' => 'ok'];
+        $user     = User::where('email', $email)->whereNull('deleted_at')->first();
+
+        if (!$user) {
+            return response()->json($response);
+        }
+
+        $dedupeTtlSeconds = 300;
+        $emailKey         = 'password-reset:email:' . sha1($email);
+        $ipKey            = 'password-reset:ip:' . sha1((string) $request->ip());
+
+        if (!Cache::add($emailKey, true, $dedupeTtlSeconds) || !Cache::add($ipKey, true, $dedupeTtlSeconds)) {
+            return response()->json($response);
+        }
 
         VerificationCode::where('subject_uuid', $user->uuid)
             ->where('for', 'password_reset')
@@ -585,7 +598,7 @@ class AuthController extends Controller
         // notify user of password reset
         $user->notify(new UserForgotPassword($verificationCode));
 
-        return response()->json(['status' => 'ok']);
+        return response()->json($response);
     }
 
     /**

--- a/src/Http/Controllers/Internal/v1/AuthController.php
+++ b/src/Http/Controllers/Internal/v1/AuthController.php
@@ -13,6 +13,7 @@ use Fleetbase\Http\Requests\JoinOrganizationRequest;
 use Fleetbase\Http\Requests\LoginRequest;
 use Fleetbase\Http\Requests\SignUpRequest;
 use Fleetbase\Http\Requests\SwitchOrganizationRequest;
+use Fleetbase\Http\Resources\AuthOrganization;
 use Fleetbase\Http\Resources\Organization;
 use Fleetbase\Mail\UserCredentialsMail;
 use Fleetbase\Models\Company;
@@ -368,28 +369,27 @@ class AuthController extends Controller
      */
     public function createVerificationSession(Request $request)
     {
-        $send                     = $request->boolean('send');
-        $email                    = $request->input('email');
-        $token                    = Str::random(40);
-        $verificationSessionToken = base64_encode($email . '|' . $token);
+        $send  = $request->boolean('send');
+        $email = strtolower((string) $request->input('email'));
+        $token = Str::random(40);
+        $user  = User::where('email', $email)->first();
+
+        if (!$user) {
+            return response()->error('No user found with provided email address.');
+        }
 
         // If opted to send verification token along with session
         if ($send) {
-            // Get user
-            $user = User::where('email', $email)->first();
-
-            if ($user) {
-                // create verification code
-                VerificationCode::generateEmailVerificationFor($user);
-            } else {
-                Redis::del($token);
-
-                return response()->error('No user found with provided email address.');
-            }
+            VerificationCode::generateEmailVerificationFor($user, 'email_verification', [
+                'meta' => ['email' => $email],
+            ]);
         }
 
         // Store in redis
-        Redis::set($token, $verificationSessionToken, 'EX', now()->addMinutes(10)->timestamp);
+        Redis::set($token, json_encode([
+            'email'     => $email,
+            'user_uuid' => $user->uuid,
+        ]), 'EX', 600);
 
         return response()->json([
             'token'   => $token,
@@ -406,14 +406,8 @@ class AuthController extends Controller
      */
     public function validateVerificationSession(Request $request)
     {
-        $email                    = $request->input('email');
-        $token                    = $request->input('token');
-        $verificationSessionToken = base64_encode($email . '|' . $token);
-        $sessionToken             = Redis::get($token);
-        $isValid                  = $sessionToken === $verificationSessionToken;
-
         return response()->json([
-            'valid' => $isValid,
+            'valid' => $this->getVerificationSession($request) !== null,
         ]);
     }
 
@@ -426,26 +420,16 @@ class AuthController extends Controller
      */
     public function sendVerificationEmail(Request $request)
     {
-        $email                    = $request->input('email');
-        $token                    = $request->input('token');
-        $verificationSessionToken = base64_encode($email . '|' . $token);
-        $sessionToken             = Redis::get($token);
-        $isValid                  = $sessionToken === $verificationSessionToken;
+        $verificationSession = $this->getVerificationSession($request);
 
         // Check in session
-        if (!$isValid) {
+        if (!$verificationSession) {
             return response()->error('Invalid verification session.');
         }
 
-        // Get user
-        $user = User::where('email', $email)->first();
-
-        if ($user) {
-            // create verification code
-            VerificationCode::generateEmailVerificationFor($user);
-        } else {
-            return response()->error('No user found with provided email address.');
-        }
+        VerificationCode::generateEmailVerificationFor($verificationSession['user'], 'email_verification', [
+            'meta' => ['email' => $verificationSession['email']],
+        ]);
 
         return response()->json([
             'status' => 'success',
@@ -461,36 +445,41 @@ class AuthController extends Controller
      */
     public function verifyEmail(Request $request)
     {
-        $authenticate             = $request->boolean('authenticate');
-        $token                    = $request->input('token');
-        $email                    = $request->input('email');
-        $code                     = $request->input('code');
-        $verificationSessionToken = base64_encode($email . '|' . $token);
-        $sessionToken             = Redis::get($token);
-        $isValid                  = $sessionToken === $verificationSessionToken;
+        $authenticate        = $request->boolean('authenticate');
+        $code                = $request->input('code');
+        $verificationSession = $this->getVerificationSession($request);
 
         // Check in session
-        if (!$isValid) {
+        if (!$verificationSession) {
             return response()->error('Invalid verification session.');
         }
 
-        // Check user
-        $user = User::where('email', $email)->first();
-        if (!$user) {
-            return response()->error('No user found with provided email.');
-        }
+        $user = $verificationSession['user'];
 
         // If user is already verified
         if ($user->isVerified()) {
             return response()->error('User is already verified.');
         }
 
+        $verificationCode = VerificationCode::where('subject_uuid', $user->uuid)
+            ->where('for', 'email_verification')
+            ->where('status', 'active')
+            ->where('code', $code)
+            ->first();
+
+        if (!$verificationCode) {
+            return response()->error('Invalid verification code.');
+        }
+
         // Verify the user using the verification code
         try {
-            $user->verify($code);
+            $user->verify($verificationCode);
         } catch (InvalidVerificationCodeException $e) {
             return response()->error('Invalid verification code.');
         }
+
+        $verificationCode->delete();
+        Redis::del($request->input('token'));
 
         // Activate user
         $user->activate();
@@ -575,7 +564,13 @@ class AuthController extends Controller
      */
     public function createPasswordReset(UserForgotPasswordRequest $request)
     {
-        $user = User::where('email', $request->input('email'))->first();
+        $email = strtolower((string) $request->input('email'));
+        $user  = User::where('email', $email)->first();
+
+        VerificationCode::where('subject_uuid', $user->uuid)
+            ->where('for', 'password_reset')
+            ->where('status', 'active')
+            ->delete();
 
         // create verification code
         $verificationCode = VerificationCode::create([
@@ -583,6 +578,7 @@ class AuthController extends Controller
             'subject_type' => Utils::getModelClassName($user),
             'for'          => 'password_reset',
             'expires_at'   => Carbon::now()->addMinutes(15),
+            'meta'         => ['email' => $email],
             'status'       => 'active',
         ]);
 
@@ -599,16 +595,16 @@ class AuthController extends Controller
      */
     public function resetPassword(ResetPasswordRequest $request)
     {
-        $verificationCode = VerificationCode::where('code', $request->input('code'))->with(['subject'])->first();
-        $link             = $request->input('link');
-        $password         = $request->input('password');
-        // If link isn't valid
-        if ($verificationCode->uuid !== $link) {
-            return response()->error('Invalid password reset request!');
-        }
+        $verificationCode = VerificationCode::where('uuid', $request->input('link'))
+            ->where('code', $request->input('code'))
+            ->where('for', 'password_reset')
+            ->where('status', 'active')
+            ->with(['subject'])
+            ->first();
+        $password = $request->input('password');
 
         // if no subject error
-        if (!isset($verificationCode->subject)) {
+        if (!$verificationCode || !($verificationCode->subject instanceof User)) {
             return response()->error('Invalid password reset request!');
         }
 
@@ -622,6 +618,96 @@ class AuthController extends Controller
     }
 
     /**
+     * Confirm a pending user email change.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function confirmEmailChange(Request $request)
+    {
+        $verificationCode = VerificationCode::where('uuid', $request->input('link'))
+            ->where('code', $request->input('code'))
+            ->where('for', 'email_change')
+            ->where('status', 'active')
+            ->with(['subject'])
+            ->first();
+
+        if (!$verificationCode || !($verificationCode->subject instanceof User)) {
+            return response()->error('Invalid email change request!');
+        }
+
+        $user     = $verificationCode->subject;
+        $oldEmail = strtolower((string) data_get($verificationCode->meta, 'old_email'));
+        $newEmail = strtolower((string) data_get($verificationCode->meta, 'new_email'));
+
+        if (!$oldEmail || !$newEmail) {
+            return response()->error('Invalid email change request!');
+        }
+
+        if (strtolower((string) $user->email) !== $oldEmail) {
+            return response()->error('This email change request is no longer valid.');
+        }
+
+        $emailAlreadyExists = User::where('email', $newEmail)
+            ->where('uuid', '!=', $user->uuid)
+            ->whereNull('deleted_at')
+            ->exists();
+
+        if ($emailAlreadyExists) {
+            return response()->error('An account with this email address already exists.');
+        }
+
+        $user->email             = $newEmail;
+        $user->email_verified_at = Carbon::now();
+        $user->save();
+
+        VerificationCode::where('subject_uuid', $user->uuid)
+            ->whereIn('for', ['password_reset', 'email_verification', 'email_change'])
+            ->where('status', 'active')
+            ->delete();
+
+        return response()->json([
+            'status'      => 'ok',
+            'verified_at' => $user->email_verified_at,
+        ]);
+    }
+
+    private function getVerificationSession(Request $request): ?array
+    {
+        $email        = strtolower((string) $request->input('email'));
+        $token        = (string) $request->input('token');
+        $sessionToken = $token ? Redis::get($token) : null;
+
+        if (!$email || !$sessionToken) {
+            return null;
+        }
+
+        $payload = json_decode($sessionToken, true);
+
+        if (!is_array($payload)) {
+            return null;
+        }
+
+        $sessionEmail = strtolower((string) data_get($payload, 'email'));
+        $userUuid     = data_get($payload, 'user_uuid');
+
+        if (!$sessionEmail || !$userUuid || !hash_equals($sessionEmail, $email)) {
+            return null;
+        }
+
+        $user = User::where('uuid', $userUuid)->first();
+
+        if (!$user || strtolower((string) $user->email) !== $sessionEmail) {
+            return null;
+        }
+
+        return [
+            'email' => $sessionEmail,
+            'token' => $token,
+            'user'  => $user,
+        ];
+    }
+
+    /**
      * Simple check if verificationc code is still valid.
      *
      * @return \Illuminate\Http\Response
@@ -629,7 +715,14 @@ class AuthController extends Controller
     public function validateVerificationCode(Request $request)
     {
         $id    = $request->input('id');
-        $valid = VerificationCode::where('uuid', $id)->exists();
+        $for   = $request->input('for');
+        $query = VerificationCode::where('uuid', $id);
+
+        if ($for) {
+            $query->where('for', $for)->where('status', 'active');
+        }
+
+        $valid = $query->exists();
 
         return response()->json(['is_valid' => $valid, 'id' => $id]);
     }
@@ -643,30 +736,41 @@ class AuthController extends Controller
     public function getUserOrganizations(Request $request)
     {
         $user     = $request->user();
-        $cacheKey = "user_organizations_{$user->uuid}";
+        $cacheKey = "user_organizations_v2_{$user->uuid}";
 
         // Cache for 30 minutes
         $companies = Cache::remember($cacheKey, 60 * 30, function () use ($user) {
             return Company::select([
+                'companies.id',
                 'companies.uuid',
+                'companies.public_id',
                 'companies.name',
+                'companies.description',
                 'companies.phone',
+                'companies.logo_uuid',
+                'companies.backdrop_uuid',
                 'companies.options',
                 'companies.currency',
+                'companies.country',
                 'companies.timezone',
+                'companies.plan',
+                'companies.trial_ends_at',
                 'companies.status',
                 'companies.type',
+                'companies.slug',
                 'companies.owner_uuid',
+                'companies.onboarding_completed_at',
                 'companies.created_at',
                 'companies.updated_at',
+                'company_users.created_at as joined_at',
             ])
+                ->withCount('users as users_count')
                 ->join('company_users', 'companies.uuid', '=', 'company_users.company_uuid')
                 ->where('company_users.user_uuid', $user->uuid)
                 ->whereNull('company_users.deleted_at')
                 ->whereNotNull('companies.owner_uuid')
                 ->with([
                     'owner:uuid,company_uuid,name,email,updated_at',
-                    'owner.companyUser:uuid,user_uuid,company_uuid,updated_at',
                 ])
                 ->distinct()
                 ->get();
@@ -688,7 +792,7 @@ class AuthController extends Controller
         $etagPayload .= '|count:' . $companies->count();
         $etag = sha1($etagPayload);
 
-        return Organization::collection($companies)
+        return AuthOrganization::collection($companies)
             ->response()
             ->setEtag($etag)
             ->header('Cache-Control', 'private, no-cache, must-revalidate');
@@ -702,6 +806,7 @@ class AuthController extends Controller
     public static function clearUserOrganizationsCache(string $userUuid)
     {
         Cache::forget("user_organizations_{$userUuid}");
+        Cache::forget("user_organizations_v2_{$userUuid}");
     }
 
     /**

--- a/src/Http/Controllers/Internal/v1/ChatChannelController.php
+++ b/src/Http/Controllers/Internal/v1/ChatChannelController.php
@@ -38,7 +38,7 @@ class ChatChannelController extends FleetbaseController
             ]);
 
             foreach ($participants as $userId) {
-                $user = User::where('uuid', $userId)->orWhere('public_id', $userId)->first();
+                $user = $this->companyUserQuery($userId)->first();
 
                 if (!$user || $user->uuid === session('user')) {
                     continue;
@@ -70,7 +70,7 @@ class ChatChannelController extends FleetbaseController
     {
         $query         = $request->input('query');
         $chatChannelId = $request->input('channel');
-        $chatChannel   = $chatChannelId ? ChatChannel::where('uuid', $chatChannelId)->orWhere('public_id', $chatChannelId)->first() : null;
+        $chatChannel   = $chatChannelId ? $this->companyChatChannelQuery($chatChannelId)->first() : null;
 
         $users = User::whereHas('companyUsers', function ($query) {
             $query->where('company_uuid', session('company'));
@@ -102,7 +102,13 @@ class ChatChannelController extends FleetbaseController
      */
     public function getUnreadCountForChannel(string $channelId, Request $request)
     {
-        $chatChannel = ChatChannel::where('uuid', $channelId)->first();
+        $userUuid     = $request->user()?->uuid;
+        $chatChannel  = ChatChannel::where('company_uuid', session('company'))
+            ->where('uuid', $channelId)
+            ->whereHas('participants', function ($query) use ($userUuid) {
+                $query->where('user_uuid', $userUuid);
+            })
+            ->first();
         if (!$chatChannel) {
             return response()->json(['error' => 'Chat channel not found.'], 404);
         }
@@ -135,5 +141,23 @@ class ChatChannelController extends FleetbaseController
         }
 
         return response()->json(['unreadCount' => $unreadCount]);
+    }
+
+    protected function companyUserQuery(string $id)
+    {
+        return User::where(function ($query) use ($id) {
+            $query->where('uuid', $id)->orWhere('public_id', $id);
+        })
+            ->whereHas('companyUsers', function ($query) {
+                $query->where('company_uuid', session('company'));
+            });
+    }
+
+    protected function companyChatChannelQuery(string $id)
+    {
+        return ChatChannel::where('company_uuid', session('company'))
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            });
     }
 }

--- a/src/Http/Controllers/Internal/v1/CompanyController.php
+++ b/src/Http/Controllers/Internal/v1/CompanyController.php
@@ -2,6 +2,7 @@
 
 namespace Fleetbase\Http\Controllers\Internal\v1;
 
+use Fleetbase\Exceptions\FleetbaseRequestValidationException;
 use Fleetbase\Exports\CompanyExport;
 use Fleetbase\Http\Controllers\FleetbaseController;
 use Fleetbase\Http\Requests\AdminRequest;
@@ -17,6 +18,7 @@ use Fleetbase\Support\Auth;
 use Fleetbase\Support\TwoFactorAuth;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -28,6 +30,75 @@ class CompanyController extends FleetbaseController
      * @var string
      */
     public $resource = 'company';
+
+    /**
+     * Find an organization visible to the current session company.
+     *
+     * @return \Illuminate\Http\Response|array
+     */
+    public function findRecord(Request $request, $id)
+    {
+        $company = $this->resolveVisibleCompany($id);
+
+        if (!$company) {
+            return response()->error('Organization not found.', 404);
+        }
+
+        return [$this->resourceSingularlName => new $this->resource($company)];
+    }
+
+    /**
+     * Update only the current session organization through generic REST.
+     *
+     * @return \Illuminate\Http\Response|array
+     */
+    public function updateRecord(Request $request, string $id)
+    {
+        $company = $this->resolveVisibleCompany($id);
+
+        if (!$company) {
+            return response()->error('Organization not found.', 404);
+        }
+
+        try {
+            $input = $this->model->getApiPayloadFromRequest($request);
+            $input = $this->model->fillSessionAttributes($input, [], ['updated_by_uuid']);
+
+            if ($this->model->isColumn('slug')) {
+                unset($input['slug']);
+            }
+
+            foreach (array_keys($input) as $key) {
+                if ($this->model->isInvalidUpdateParam($key)) {
+                    throw new \Exception('Invalid param "' . $key . '" in update request!');
+                }
+            }
+
+            $company->update(Arr::except($input, ['uuid', 'public_id', 'deleted_at', 'updated_at', 'created_at']));
+
+            return [$this->resourceSingularlName => new $this->resource($company->refresh())];
+        } catch (\Illuminate\Database\QueryException $e) {
+            return response()->error($e->getMessage());
+        } catch (FleetbaseRequestValidationException $e) {
+            return response()->error($e->getErrors());
+        } catch (\Exception $e) {
+            return response()->error($e->getMessage());
+        }
+    }
+
+    /**
+     * Disable generic organization deletion.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function deleteRecord($id, Request $request)
+    {
+        if (!$this->resolveVisibleCompany($id)) {
+            return response()->error('Organization not found.', 404);
+        }
+
+        return response()->error('Generic organization deletion is not supported.', 403);
+    }
 
     /**
      * Find company by public_id or invitation code.
@@ -176,6 +247,21 @@ class CompanyController extends FleetbaseController
             return Company::where('uuid', $id)->orWhere('public_id', $id)->first();
         }
 
+        $sessionCompany = session('company');
+
+        if (!$sessionCompany) {
+            return null;
+        }
+
+        return Company::where('uuid', $sessionCompany)
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            })
+            ->first();
+    }
+
+    private function resolveVisibleCompany(string $id): ?Company
+    {
         $sessionCompany = session('company');
 
         if (!$sessionCompany) {

--- a/src/Http/Controllers/Internal/v1/CompanyController.php
+++ b/src/Http/Controllers/Internal/v1/CompanyController.php
@@ -102,18 +102,19 @@ class CompanyController extends FleetbaseController
      */
     public function users(string $id, Request $request)
     {
+        $company = $this->resolveVisibleCompanyForUsers($id, $request);
+
+        if (!$company) {
+            return response()->json(['error' => 'Organization not found.'], 404);
+        }
+
         $searchQuery = $request->searchQuery();
         $limit       = $request->input(['limit', 'nestedLimit'], 20);
         $paginate    = $request->boolean('paginate');
         $exclude     = $request->array('exclude');
 
         // Start user query
-        $usersQuery = CompanyUser::whereHas('company',
-            function ($query) use ($id) {
-                $query->where('public_id', $id);
-                $query->orWhere('uuid', $id);
-            }
-        )
+        $usersQuery = CompanyUser::where('company_uuid', $company->uuid)
         ->whereHas('user')
         ->whereNotIn('user_uuid', $exclude)
         ->with(['user']);
@@ -165,6 +166,27 @@ class CompanyController extends FleetbaseController
         });
 
         return UserResource::collection($users);
+    }
+
+    private function resolveVisibleCompanyForUsers(string $id, Request $request): ?Company
+    {
+        $user = $request->user();
+
+        if ($user && $user->isAdmin()) {
+            return Company::where('uuid', $id)->orWhere('public_id', $id)->first();
+        }
+
+        $sessionCompany = session('company');
+
+        if (!$sessionCompany) {
+            return null;
+        }
+
+        return Company::where('uuid', $sessionCompany)
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            })
+            ->first();
     }
 
     public function extensions(string $id, AdminRequest $request): JsonResponse

--- a/src/Http/Controllers/Internal/v1/CompanyController.php
+++ b/src/Http/Controllers/Internal/v1/CompanyController.php
@@ -544,11 +544,21 @@ class CompanyController extends FleetbaseController
         $companyId      = $request->input('company');
         $newOwnerId     = $request->input('newOwner');
         $leave          = $request->boolean('leave');
+        $sessionCompany = session('company');
+        $currentUser    = $request->user();
+
+        if (!$currentUser || !$sessionCompany || ($companyId && $companyId !== $sessionCompany)) {
+            return response()->error('No organization found to transfer ownership for.');
+        }
 
         // Get and validate organization
-        $company = Company::where('uuid', $companyId)->first();
+        $company = Company::where('uuid', $sessionCompany)->first();
         if (!$company) {
             return response()->error('No organization found to transfer ownership for.');
+        }
+
+        if (!$company->isOwner($currentUser)) {
+            return response()->error('Only the organization owner can transfer ownership.', 403);
         }
 
         // Get and validate the new owner
@@ -557,22 +567,23 @@ class CompanyController extends FleetbaseController
             return response()->error('The new owner provided could not be found for transfer of ownership.');
         }
 
+        if ($leave && $newOwner->uuid === $currentUser->uuid) {
+            return response()->error('Select a different organization member before leaving.', 422);
+        }
+
         // Change the company owner
         $company->assignOwner($newOwner);
 
         // If the current user has opted to leave, remove them from the organization
         if ($leave) {
-            $currentUser = $request->user();
-            if ($currentUser) {
-                $currentCompanyUser = $company->getCompanyUserPivot($currentUser);
-                if ($currentCompanyUser) {
-                    $currentCompanyUser->delete();
-                }
-                // Switch organization
-                $nextOrganization = $currentUser->companies()->where('companies.uuid', '!=', $company->uuid)->first();
-                if ($nextOrganization) {
-                    $currentUser->setCompany($nextOrganization);
-                }
+            $currentCompanyUser = $company->getCompanyUserPivot($currentUser);
+            if ($currentCompanyUser) {
+                $currentCompanyUser->delete();
+            }
+            // Switch organization
+            $nextOrganization = $currentUser->companies()->where('companies.uuid', '!=', $company->uuid)->first();
+            if ($nextOrganization) {
+                $currentUser->setCompany($nextOrganization);
             }
         }
 
@@ -591,18 +602,22 @@ class CompanyController extends FleetbaseController
     public function leaveOrganization(Request $request)
     {
         $companyId        = $request->input('company');
-        $currentUserId    = $request->input('user');
-        $currentUser      = Str::isUuid($currentUserId) ? User::where('uuid', $currentUserId)->first() : Auth::getUserFromSession($request);
+        $sessionCompany   = session('company');
+        $currentUser      = $request->user() ?? Auth::getUserFromSession($request);
 
         // If not current user - error
-        if (!$currentUser) {
+        if (!$currentUser || !$sessionCompany || ($companyId && $companyId !== $sessionCompany)) {
             return response()->error('Unable to leave organization.');
         }
 
         // Get and validate organization
-        $company = Company::where('uuid', $companyId)->first();
+        $company = Company::where('uuid', $sessionCompany)->first();
         if (!$company) {
             return response()->error('No organization found for user to leave.');
+        }
+
+        if ($company->isOwner($currentUser)) {
+            return response()->error('Transfer ownership before leaving the organization.', 403);
         }
 
         $currentCompanyUser = $company->getCompanyUserPivot($currentUser);

--- a/src/Http/Controllers/Internal/v1/FileController.php
+++ b/src/Http/Controllers/Internal/v1/FileController.php
@@ -328,8 +328,10 @@ class FileController extends FleetbaseController
             abort(400, 'Missing file identifier.');
         }
 
-        $disk     = $request->input('disk', config('filesystems.default'));
-        $file     = File::where('uuid', $fileId)->firstOrFail();
+        $file     = File::where('uuid', $fileId)
+            ->where('company_uuid', session('company'))
+            ->firstOrFail();
+        $disk     = $file->disk ?: config('filesystems.default');
         $filename = $file->original_filename ?: basename($file->path);
 
         /** @var \Illuminate\Filesystem\FilesystemAdapter $filesystem */

--- a/src/Http/Controllers/Internal/v1/NotificationController.php
+++ b/src/Http/Controllers/Internal/v1/NotificationController.php
@@ -5,6 +5,7 @@ namespace Fleetbase\Http\Controllers\Internal\v1;
 use Fleetbase\Http\Controllers\FleetbaseController;
 use Fleetbase\Models\Notification;
 use Fleetbase\Models\Setting;
+use Fleetbase\Models\User;
 use Fleetbase\Support\NotificationRegistry;
 use Illuminate\Http\Request;
 
@@ -34,7 +35,7 @@ class NotificationController extends FleetbaseController
         $read          = [];
 
         foreach ($notifications as $id) {
-            $notification = Notification::where('id', $id)->first();
+            $notification = $this->notificationQuery()->where('id', $id)->first();
 
             if ($notification) {
                 $read[] = $notification->markAsRead();
@@ -56,7 +57,7 @@ class NotificationController extends FleetbaseController
      */
     public function markAllAsRead()
     {
-        $notifications = Notification::where('notifiable_id', session('user'))->get();
+        $notifications = $this->notificationQuery()->get();
 
         foreach ($notifications as $notification) {
             $notification->markAsRead();
@@ -77,7 +78,7 @@ class NotificationController extends FleetbaseController
      */
     public function deleteNotification($notificationId)
     {
-        $notification = Notification::find($notificationId);
+        $notification = $this->notificationQuery()->where('id', $notificationId)->first();
 
         if ($notification) {
             $notification->deleteNotification();
@@ -100,15 +101,44 @@ class NotificationController extends FleetbaseController
         $notifications = $request->input('notifications');
 
         if (empty($notifications)) {
-            Notification::where('notifiable_id', session('user'))->delete();
+            $this->notificationQuery()->delete();
         } else {
-            Notification::whereIn('id', $notifications)->delete();
+            $this->notificationQuery()->whereIn('id', $notifications)->delete();
         }
 
         return response()->json([
             'status'  => 'ok',
             'message' => 'Selected notifications deleted successfully',
         ]);
+    }
+
+    /**
+     * Deletes a notification belonging to the authenticated user.
+     *
+     * @param string|int $id the ID of the notification to delete
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function deleteRecord($id, Request $request)
+    {
+        $notification = $this->notificationQuery()->where('id', $id)->first();
+
+        if (!$notification) {
+            return response()->json(['error' => 'Notification not found'], 404);
+        }
+
+        $notification->deleteNotification();
+
+        return response()->json(['message' => 'Notification deleted successfully'], 200);
+    }
+
+    /**
+     * Base query for notifications owned by the authenticated user.
+     */
+    protected function notificationQuery()
+    {
+        return Notification::where('notifiable_id', session('user'))
+            ->where('notifiable_type', User::class);
     }
 
     /**

--- a/src/Http/Controllers/Internal/v1/PolicyController.php
+++ b/src/Http/Controllers/Internal/v1/PolicyController.php
@@ -82,7 +82,9 @@ class PolicyController extends FleetbaseController
     public function deleteRecord($id, Request $request)
     {
         $id     = $request->segment(4);
-        $policy = Policy::find($id);
+        $policy = Policy::where('id', $id)
+            ->where('company_uuid', session('company'))
+            ->first();
 
         if (!$policy) {
             return response()->error('Unable to find policy for deletion.');

--- a/src/Http/Controllers/Internal/v1/ReportController.php
+++ b/src/Http/Controllers/Internal/v1/ReportController.php
@@ -197,7 +197,7 @@ class ReportController extends FleetbaseController
     public function execute(Request $request, string $id): JsonResponse
     {
         try {
-            $report = Report::where('uuid', $id)->firstOrFail();
+            $report = $this->reportQuery($id)->firstOrFail();
 
             // Validate query configuration before execution
             $validationResult = $this->queryValidator->validate($report->query_config);
@@ -315,7 +315,7 @@ class ReportController extends FleetbaseController
     public function export(Request $request, string $id): JsonResponse
     {
         try {
-            $report  = Report::where('uuid', $id)->firstOrFail();
+            $report  = $this->reportQuery($id)->firstOrFail();
             $format  = $request->input('format', 'csv');
             $options = $request->input('options', []);
 
@@ -672,5 +672,11 @@ class ReportController extends FleetbaseController
                 500
             );
         }
+    }
+
+    protected function reportQuery(string $id)
+    {
+        return Report::where('uuid', $id)
+            ->where('company_uuid', session('company'));
     }
 }

--- a/src/Http/Controllers/Internal/v1/RoleController.php
+++ b/src/Http/Controllers/Internal/v1/RoleController.php
@@ -6,6 +6,7 @@ use Fleetbase\Exceptions\FleetbaseRequestValidationException;
 use Fleetbase\Http\Controllers\FleetbaseController;
 use Fleetbase\Models\Permission;
 use Fleetbase\Models\Policy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -48,7 +49,7 @@ class RoleController extends FleetbaseController
 
                 // Sync Policies
                 if ($request->isArray('role.policies')) {
-                    $policies = Policy::whereIn('id', $request->array('role.policies'))->get();
+                    $policies = $this->getAssignablePolicies($request->array('role.policies'));
                     $role->syncPolicies($policies);
                 }
             });
@@ -80,7 +81,7 @@ class RoleController extends FleetbaseController
 
                 // Sync Policies
                 if ($request->isArray('role.policies')) {
-                    $policies = Policy::whereIn('id', $request->array('role.policies'))->get();
+                    $policies = $this->getAssignablePolicies($request->array('role.policies'));
                     $role->syncPolicies($policies);
                 }
             });
@@ -93,5 +94,18 @@ class RoleController extends FleetbaseController
         } catch (FleetbaseRequestValidationException $e) {
             return response()->error($e->getErrors());
         }
+    }
+
+    /**
+     * Resolve policies that can be assigned by the active company.
+     */
+    protected function getAssignablePolicies(array $ids)
+    {
+        return Policy::whereIn('id', $ids)
+            ->where(function (Builder $query) {
+                $query->where('company_uuid', session('company'))
+                    ->orWhereNull('company_uuid');
+            })
+            ->get();
     }
 }

--- a/src/Http/Controllers/Internal/v1/ScheduleExceptionController.php
+++ b/src/Http/Controllers/Internal/v1/ScheduleExceptionController.php
@@ -36,8 +36,7 @@ class ScheduleExceptionController extends FleetbaseController
      */
     public function approve(string $id): JsonResponse
     {
-        $exception = ScheduleException::where('uuid', $id)
-            ->orWhere('public_id', $id)
+        $exception = $this->scheduleExceptionQuery($id)
             ->firstOrFail();
 
         $reviewerUuid = auth()->user()?->uuid;
@@ -57,8 +56,7 @@ class ScheduleExceptionController extends FleetbaseController
      */
     public function reject(string $id): JsonResponse
     {
-        $exception = ScheduleException::where('uuid', $id)
-            ->orWhere('public_id', $id)
+        $exception = $this->scheduleExceptionQuery($id)
             ->firstOrFail();
 
         $reviewerUuid = auth()->user()?->uuid;
@@ -89,10 +87,20 @@ class ScheduleExceptionController extends FleetbaseController
 
         $filters = $request->only(['status', 'type', 'start_at', 'end_at']);
 
-        $exceptions = $this->scheduleService->getExceptionsForSubject($subjectType, $subjectUuid, $filters);
+        $exceptions = $this->scheduleService->getExceptionsForSubject($subjectType, $subjectUuid, $filters)
+            ->where('company_uuid', session('company'))
+            ->values();
 
         return response()->json([
             'schedule_exceptions' => \Fleetbase\Http\Resources\ScheduleException::collection($exceptions),
         ]);
+    }
+
+    protected function scheduleExceptionQuery(string $id)
+    {
+        return ScheduleException::where('company_uuid', session('company'))
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            });
     }
 }

--- a/src/Http/Controllers/Internal/v1/ScheduleTemplateController.php
+++ b/src/Http/Controllers/Internal/v1/ScheduleTemplateController.php
@@ -44,12 +44,10 @@ class ScheduleTemplateController extends FleetbaseController
             'schedule_uuid' => 'required|string',
         ]);
 
-        $template = ScheduleTemplate::where('uuid', $id)
-            ->orWhere('public_id', $id)
+        $template = $this->scheduleTemplateQuery($id)
             ->firstOrFail();
 
-        $schedule = Schedule::where('uuid', $request->input('schedule_uuid'))
-            ->orWhere('public_id', $request->input('schedule_uuid'))
+        $schedule = $this->scheduleQuery($request->input('schedule_uuid'))
             ->firstOrFail();
 
         // applyTemplateToSchedule now returns ['template' => $applied, 'items_created' => $count]
@@ -70,8 +68,7 @@ class ScheduleTemplateController extends FleetbaseController
      */
     public function materialize(string $id): JsonResponse
     {
-        $template = ScheduleTemplate::where('uuid', $id)
-            ->orWhere('public_id', $id)
+        $template = $this->scheduleTemplateQuery($id)
             ->whereNotNull('schedule_uuid')
             ->firstOrFail();
 
@@ -87,5 +84,21 @@ class ScheduleTemplateController extends FleetbaseController
             'status'        => 'ok',
             'items_created' => $created,
         ]);
+    }
+
+    protected function scheduleTemplateQuery(string $id)
+    {
+        return ScheduleTemplate::where('company_uuid', session('company'))
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            });
+    }
+
+    protected function scheduleQuery(string $id)
+    {
+        return Schedule::where('company_uuid', session('company'))
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            });
     }
 }

--- a/src/Http/Controllers/Internal/v1/SettingController.php
+++ b/src/Http/Controllers/Internal/v1/SettingController.php
@@ -8,6 +8,7 @@ use Fleetbase\Models\File;
 use Fleetbase\Models\Setting;
 use Fleetbase\Notifications\TestPushNotification;
 use Fleetbase\Services\SmsService;
+use Fleetbase\Support\PlatformApi;
 use Fleetbase\Support\Utils;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\AnonymousNotifiable;
@@ -34,6 +35,42 @@ class SettingController extends Controller
         $metrics['total_transactions']  = \Fleetbase\Models\Transaction::all()->count();
 
         return response()->json($metrics);
+    }
+
+    /**
+     * Get platform API token status.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getPlatformApiToken(AdminRequest $request)
+    {
+        return response()->json(PlatformApi::status());
+    }
+
+    /**
+     * Rotate the platform API token.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function rotatePlatformApiToken(AdminRequest $request)
+    {
+        $token = PlatformApi::rotateToken();
+
+        return response()->json(array_merge(PlatformApi::status(), [
+            'token' => $token,
+        ]));
+    }
+
+    /**
+     * Revoke the platform API token.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function revokePlatformApiToken(AdminRequest $request)
+    {
+        PlatformApi::revokeToken();
+
+        return response()->json(PlatformApi::status());
     }
 
     /**

--- a/src/Http/Controllers/Internal/v1/TemplateController.php
+++ b/src/Http/Controllers/Internal/v1/TemplateController.php
@@ -108,13 +108,14 @@ class TemplateController extends FleetbaseController
         $queryModels = collect($rawQueries)->map(function ($q) {
             $tq = new TemplateQuery();
             $tq->fill([
-                'label'         => data_get($q, 'label'),
-                'variable_name' => data_get($q, 'variable_name'),
-                'model_type'    => data_get($q, 'model_type'),
-                'conditions'    => data_get($q, 'conditions', []),
-                'sort'          => data_get($q, 'sort', []),
-                'limit'         => data_get($q, 'limit'),
-                'with'          => data_get($q, 'with', []),
+                'company_uuid'   => session('company'),
+                'label'          => data_get($q, 'label'),
+                'variable_name'  => data_get($q, 'variable_name'),
+                'model_type'     => data_get($q, 'model_type'),
+                'conditions'     => data_get($q, 'conditions', []),
+                'sort'           => data_get($q, 'sort', []),
+                'limit'          => data_get($q, 'limit'),
+                'with'           => data_get($q, 'with', []),
             ]);
 
             return $tq;

--- a/src/Http/Controllers/Internal/v1/TemplateController.php
+++ b/src/Http/Controllers/Internal/v1/TemplateController.php
@@ -7,9 +7,11 @@ use Fleetbase\Http\Requests\Internal\CreateTemplateRequest;
 use Fleetbase\Models\Template;
 use Fleetbase\Models\TemplateQuery;
 use Fleetbase\Services\TemplateRenderService;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class TemplateController extends FleetbaseController
@@ -126,11 +128,7 @@ class TemplateController extends FleetbaseController
         $subjectId   = $request->input('subject_id');
         $subject     = null;
 
-        if ($subjectType && $subjectId && class_exists($subjectType)) {
-            $subject = $subjectType::where('uuid', $subjectId)
-                ->orWhere('public_id', $subjectId)
-                ->first();
-        }
+        $subject = $this->resolveTemplateSubject($subjectType, $subjectId);
 
         $html = $this->renderService->renderToHtml($template, $subject);
 
@@ -148,19 +146,14 @@ class TemplateController extends FleetbaseController
      */
     public function preview(string $id, Request $request): JsonResponse
     {
-        $template = Template::where('uuid', $id)
-            ->orWhere('public_id', $id)
+        $template = $this->templateQuery($id)
             ->firstOrFail();
 
         $subjectType = $request->input('subject_type');
         $subjectId   = $request->input('subject_id');
         $subject     = null;
 
-        if ($subjectType && $subjectId && class_exists($subjectType)) {
-            $subject = $subjectType::where('uuid', $subjectId)
-                ->orWhere('public_id', $subjectId)
-                ->first();
-        }
+        $subject = $this->resolveTemplateSubject($subjectType, $subjectId);
 
         $html = $this->renderService->renderToHtml($template, $subject);
 
@@ -179,8 +172,7 @@ class TemplateController extends FleetbaseController
      */
     public function render(string $id, Request $request): Response
     {
-        $template = Template::where('uuid', $id)
-            ->orWhere('public_id', $id)
+        $template = $this->templateQuery($id)
             ->firstOrFail();
 
         $subjectType = $request->input('subject_type');
@@ -188,11 +180,7 @@ class TemplateController extends FleetbaseController
         $filename    = $request->input('filename', $template->name);
         $subject     = null;
 
-        if ($subjectType && $subjectId && class_exists($subjectType)) {
-            $subject = $subjectType::where('uuid', $subjectId)
-                ->orWhere('public_id', $subjectId)
-                ->first();
-        }
+        $subject = $this->resolveTemplateSubject($subjectType, $subjectId);
 
         $pdf = $this->renderService->renderToPdf($template, $subject);
 
@@ -210,6 +198,51 @@ class TemplateController extends FleetbaseController
         $schemas = $this->renderService->getContextSchemas();
 
         return response()->json(['schemas' => $schemas]);
+    }
+
+    protected function templateQuery(string $id)
+    {
+        return Template::where('company_uuid', session('company'))
+            ->where(function ($query) use ($id) {
+                $query->where('uuid', $id)->orWhere('public_id', $id);
+            });
+    }
+
+    protected function resolveTemplateSubject(?string $subjectType, ?string $subjectId): ?Model
+    {
+        if (!$subjectType || !$subjectId || !$this->isAllowedSubjectModel($subjectType)) {
+            return null;
+        }
+
+        /** @var Model $instance */
+        $instance = new $subjectType();
+        $query    = $subjectType::where(function ($query) use ($subjectId) {
+            $query->where('uuid', $subjectId)->orWhere('public_id', $subjectId);
+        });
+
+        if ($this->modelHasCompanyColumn($instance)) {
+            $query->where($instance->qualifyColumn('company_uuid'), session('company'));
+        }
+
+        return $query->first();
+    }
+
+    protected function isAllowedSubjectModel(string $subjectType): bool
+    {
+        $models = collect($this->renderService->getContextSchemas())
+            ->pluck('model')
+            ->filter()
+            ->values()
+            ->all();
+
+        return in_array($subjectType, $models, true) && is_subclass_of($subjectType, Model::class);
+    }
+
+    protected function modelHasCompanyColumn(Model $model): bool
+    {
+        $connection = $model->getConnectionName() ?: config('database.default');
+
+        return Schema::connection($connection)->hasColumn($model->getTable(), 'company_uuid');
     }
 
     // -------------------------------------------------------------------------

--- a/src/Http/Controllers/Internal/v1/UserController.php
+++ b/src/Http/Controllers/Internal/v1/UserController.php
@@ -108,6 +108,43 @@ class UserController extends FleetbaseController
     }
 
     /**
+     * Scope generic user list requests to users joined to the current company.
+     */
+    public function onQueryRecord($query, Request $request): void
+    {
+        if ($this->canAccessUsersAcrossCompanies($request)) {
+            return;
+        }
+
+        $companyUuid = session('company');
+        if (!$companyUuid) {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $query->whereHas('companyUsers', function ($companyUserQuery) use ($companyUuid) {
+            $companyUserQuery->where('company_uuid', $companyUuid);
+        });
+    }
+
+    /**
+     * Find a user visible to the current session company.
+     *
+     * @return \Illuminate\Http\Response|array
+     */
+    public function findRecord(Request $request, $id)
+    {
+        $record = $this->resolveVisibleUser($id, $request);
+
+        if ($record) {
+            return [$this->resourceSingularlName => new $this->resource($record)];
+        }
+
+        return response()->error('User not found', 404);
+    }
+
+    /**
      * Creates a record with request payload.
      *
      * If the supplied email address already belongs to an existing user the
@@ -201,7 +238,7 @@ class UserController extends FleetbaseController
      */
     public function updateRecord(Request $request, string $id)
     {
-        $record = $this->model->getById($id, null, $request);
+        $record = $this->resolveVisibleUser($id, $request);
 
         if (!$record) {
             return response()->error('User not found.', 404);
@@ -217,24 +254,39 @@ class UserController extends FleetbaseController
         $this->validateRequest($request);
 
         try {
-            $record = $this->model->updateRecordFromRequest($request, $id, function (&$request, &$user) {
-                // Assign role if set
-                if ($request->filled('user.role')) {
-                    $user->assignSingleRole($request->input('user.role'));
-                }
+            $input = $this->model->getApiPayloadFromRequest($request);
+            $input = $this->model->fillSessionAttributes($input, [], ['updated_by_uuid']);
 
-                // Sync Permissions
-                if ($request->isArray('user.permissions')) {
-                    $permissions = Permission::whereIn('id', $request->array('user.permissions'))->get();
-                    $user->syncPermissions($permissions);
-                }
+            if ($this->model->isColumn('slug')) {
+                unset($input['slug']);
+            }
 
-                // Sync Policies
-                if ($request->isArray('user.policies')) {
-                    $policies = Policy::whereIn('id', $request->array('user.policies'))->get();
-                    $user->syncPolicies($policies);
+            foreach (array_keys($input) as $key) {
+                if ($this->model->isInvalidUpdateParam($key)) {
+                    throw new \Exception('Invalid param "' . $key . '" in update request!');
                 }
-            });
+            }
+
+            $record->update(Arr::except($input, ['uuid', 'public_id', 'deleted_at', 'updated_at', 'created_at']));
+
+            // Assign role if set
+            if ($request->filled('user.role')) {
+                $record->assignSingleRole($request->input('user.role'));
+            }
+
+            // Sync Permissions
+            if ($request->isArray('user.permissions')) {
+                $permissions = Permission::whereIn('id', $request->array('user.permissions'))->get();
+                $record->syncPermissions($permissions);
+            }
+
+            // Sync Policies
+            if ($request->isArray('user.policies')) {
+                $policies = Policy::whereIn('id', $request->array('user.policies'))->get();
+                $record->syncPolicies($policies);
+            }
+
+            $record = $record->refresh();
 
             return ['user' => new $this->resource($record)];
         } catch (\Exception $e) {
@@ -244,6 +296,56 @@ class UserController extends FleetbaseController
         } catch (FleetbaseRequestValidationException $e) {
             return response()->error($e->getErrors());
         }
+    }
+
+    /**
+     * Disable the generic user delete endpoint for org-scoped callers.
+     *
+     * User removal from an organization must use the dedicated
+     * remove-from-company action so multi-organization users are not globally
+     * deleted by accident.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function deleteRecord($id, Request $request)
+    {
+        if (!$this->resolveVisibleUser($id, $request)) {
+            return response()->error('User not found', 404);
+        }
+
+        return response()->error('Use the remove-from-company endpoint to remove users from an organization.', 403);
+    }
+
+    private function resolveVisibleUser(string $id, Request $request): ?User
+    {
+        $query = User::where(function ($query) use ($id) {
+            $query->where('uuid', $id)
+                ->orWhere('public_id', $id);
+        });
+
+        if (!$this->canAccessUsersAcrossCompanies($request)) {
+            $companyUuid = session('company');
+            if (!$companyUuid) {
+                return null;
+            }
+
+            $query->whereHas('companyUsers', function ($companyUserQuery) use ($companyUuid) {
+                $companyUserQuery->where('company_uuid', $companyUuid);
+            });
+        }
+
+        $query = $this->model->withCounts($request, $query);
+        $query = $this->model->withRelationships($request, $query);
+        $query = $this->model->applyDirectivesToQuery($request, $query);
+
+        return $query->first();
+    }
+
+    private function canAccessUsersAcrossCompanies(Request $request): bool
+    {
+        $user = Auth::getUserFromSession($request) ?? $request->user();
+
+        return $user instanceof User && $user->isAdmin();
     }
 
     private function stripUnchangedIdentityFields(Request $request, User $user): bool

--- a/src/Http/Controllers/Internal/v1/UserController.php
+++ b/src/Http/Controllers/Internal/v1/UserController.php
@@ -10,6 +10,8 @@ use Fleetbase\Http\Controllers\FleetbaseController;
 use Fleetbase\Http\Requests\CreateUserRequest;
 use Fleetbase\Http\Requests\ExportRequest;
 use Fleetbase\Http\Requests\Internal\AcceptCompanyInvite;
+use Fleetbase\Http\Requests\Internal\ChangeCurrentUserEmailRequest;
+use Fleetbase\Http\Requests\Internal\ChangeUserEmailRequest;
 use Fleetbase\Http\Requests\Internal\InviteUserRequest;
 use Fleetbase\Http\Requests\Internal\ResendUserInvite;
 use Fleetbase\Http\Requests\Internal\UpdatePasswordRequest;
@@ -22,7 +24,9 @@ use Fleetbase\Models\Permission;
 use Fleetbase\Models\Policy;
 use Fleetbase\Models\Setting;
 use Fleetbase\Models\User;
+use Fleetbase\Models\VerificationCode;
 use Fleetbase\Notifications\UserAcceptedCompanyInvite;
+use Fleetbase\Notifications\UserEmailChange;
 use Fleetbase\Notifications\UserInvited;
 use Fleetbase\Services\UserCacheService;
 use Fleetbase\Support\Auth;
@@ -30,6 +34,7 @@ use Fleetbase\Support\NotificationRegistry;
 use Fleetbase\Support\TwoFactorAuth;
 use Fleetbase\Support\Utils;
 use Illuminate\Http\Request;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -196,6 +201,16 @@ class UserController extends FleetbaseController
      */
     public function updateRecord(Request $request, string $id)
     {
+        $record = $this->model->getById($id, null, $request);
+
+        if (!$record) {
+            return response()->error('User not found.', 404);
+        }
+
+        if (!$this->stripUnchangedIdentityFields($request, $record)) {
+            return response()->error('Login identity fields cannot be updated from this endpoint.', 422);
+        }
+
         // Run the UpdateUserRequest validation rules before delegating to the
         // model trait. This prevents email/phone being set to an empty string
         // and enforces uniqueness constraints on partial (PATCH) updates.
@@ -229,6 +244,170 @@ class UserController extends FleetbaseController
         } catch (FleetbaseRequestValidationException $e) {
             return response()->error($e->getErrors());
         }
+    }
+
+    private function stripUnchangedIdentityFields(Request $request, User $user): bool
+    {
+        $payload = $this->model->getApiPayloadFromRequest($request);
+
+        $identityFields = [
+            'email',
+            'email_verified_at',
+            'password',
+            'password_confirmation',
+            'remember_token',
+            'secret',
+            'type',
+            'apple_user_id',
+            'facebook_user_id',
+            'google_user_id',
+        ];
+
+        foreach ($identityFields as $field) {
+            if (!array_key_exists($field, $payload)) {
+                continue;
+            }
+
+            if (!$this->identityValueMatches($field, $payload[$field], $user->getAttribute($field))) {
+                return false;
+            }
+
+            unset($payload[$field]);
+        }
+
+        if ($request->has($this->model->getSingularName())) {
+            $request->merge([$this->model->getSingularName() => $payload]);
+        } elseif ($request->has(Str::camel($this->model->getSingularName()))) {
+            $request->merge([Str::camel($this->model->getSingularName()) => $payload]);
+        } else {
+            $request->replace($payload);
+        }
+
+        return true;
+    }
+
+    private function identityValueMatches(string $field, mixed $incoming, mixed $current): bool
+    {
+        if ($field === 'email') {
+            return strtolower((string) $incoming) === strtolower((string) $current);
+        }
+
+        if (str_ends_with($field, '_at')) {
+            if ($incoming === null && $current === null) {
+                return true;
+            }
+
+            if (!$incoming || !$current) {
+                return false;
+            }
+
+            try {
+                return Carbon::parse($incoming)->equalTo(Carbon::parse($current));
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        return (string) $incoming === (string) $current;
+    }
+
+    /**
+     * Request an email change for a user in the current organisation.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    #[SkipAuthorizationCheck]
+    public function changeEmail(ChangeUserEmailRequest $request, string $id)
+    {
+        $actor = Auth::getUserFromSession($request);
+        if (!$actor) {
+            return response()->error('Not authorized to change user email.', 401);
+        }
+
+        $canChangeEmail = $actor->isAdmin() || $actor->hasRole('Administrator') || $actor->hasPermissionTo('iam change-email-for user');
+        if (!$canChangeEmail) {
+            return response()->error('Not authorized to change user email.', 401);
+        }
+
+        $targetUser = User::where('uuid', $id)
+            ->whereHas('anyCompanyUser', function ($query) {
+                $query->where('company_uuid', session('company'));
+            })
+            ->first();
+
+        if (!$targetUser) {
+            return response()->error('User not found to change email for.', 404);
+        }
+
+        $newEmail = strtolower((string) $request->input('email'));
+        $oldEmail = strtolower((string) $targetUser->email);
+
+        if ($newEmail === $oldEmail) {
+            return response()->error('The new email address must be different from the current email address.');
+        }
+
+        $this->sendEmailChangeVerification($targetUser, $actor, $newEmail, $oldEmail);
+
+        return response()->json([
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * Request an email change for the current user.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    #[SkipAuthorizationCheck]
+    public function changeCurrentUserEmail(ChangeCurrentUserEmailRequest $request)
+    {
+        $user = Auth::getUserFromSession($request);
+        if (!$user) {
+            return response()->error('No user session found', 401);
+        }
+
+        $newEmail = strtolower((string) $request->input('email'));
+        $oldEmail = strtolower((string) $user->email);
+
+        if ($newEmail === $oldEmail) {
+            return response()->error('The new email address must be different from the current email address.');
+        }
+
+        $this->sendEmailChangeVerification($user, $user, $newEmail, $oldEmail);
+
+        return response()->json([
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * Send an email change verification link to a pending new email address.
+     */
+    protected function sendEmailChangeVerification(User $targetUser, User $actor, string $newEmail, string $oldEmail): VerificationCode
+    {
+        VerificationCode::where('subject_uuid', $targetUser->uuid)
+            ->where('for', 'email_change')
+            ->where('status', 'active')
+            ->delete();
+
+        $verificationCode = VerificationCode::create([
+            'subject_uuid' => $targetUser->uuid,
+            'subject_type' => Utils::getModelClassName($targetUser),
+            'for'          => 'email_change',
+            'expires_at'   => Carbon::now()->addHour(),
+            'meta'         => [
+                'old_email'         => $oldEmail,
+                'new_email'         => $newEmail,
+                'requested_by_uuid' => $actor->uuid,
+            ],
+            'status'       => 'active',
+        ]);
+
+        (new AnonymousNotifiable())
+            ->route('mail', $newEmail)
+            ->notify(new UserEmailChange($verificationCode));
+
+        return $verificationCode;
     }
 
     /**

--- a/src/Http/Controllers/Internal/v1/UserController.php
+++ b/src/Http/Controllers/Internal/v1/UserController.php
@@ -22,6 +22,7 @@ use Fleetbase\Models\CompanyUser;
 use Fleetbase\Models\Invite;
 use Fleetbase\Models\Permission;
 use Fleetbase\Models\Policy;
+use Fleetbase\Models\Role;
 use Fleetbase\Models\Setting;
 use Fleetbase\Models\User;
 use Fleetbase\Models\VerificationCode;
@@ -33,6 +34,7 @@ use Fleetbase\Support\Auth;
 use Fleetbase\Support\NotificationRegistry;
 use Fleetbase\Support\TwoFactorAuth;
 use Fleetbase\Support\Utils;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Arr;
@@ -178,6 +180,10 @@ class UserController extends FleetbaseController
             return $this->inviteExistingUser($existingUser, $request);
         }
 
+        if ($request->filled('user.role_uuid') && !$this->resolveAssignableRole($request->input('user.role_uuid'))) {
+            return response()->error('The selected role is not available for this organisation.', 404);
+        }
+
         try {
             $record = $this->model->createRecordFromRequest($request, function (&$request, &$input) {
                 // Get user properties
@@ -200,12 +206,14 @@ class UserController extends FleetbaseController
                 // Set user type
                 $user->setUserType('user');
 
+                $role = $this->resolveAssignableRole($request->input('user.role_uuid'));
+
                 // Assign to user
-                $user->assignCompany($company, $request->input('user.role_uuid'));
+                $user->assignCompany($company, $role ? $role->id : 'Administrator');
 
                 // Assign role if set
-                if ($request->filled('user.role_uuid')) {
-                    $user->assignSingleRole($request->input('user.role_uuid'));
+                if ($role) {
+                    $user->assignSingleRole($role);
                 }
 
                 // Sync Permissions
@@ -216,7 +224,7 @@ class UserController extends FleetbaseController
 
                 // Sync Policies
                 if ($request->isArray('user.policies')) {
-                    $policies = Policy::whereIn('id', $request->array('user.policies'))->get();
+                    $policies = $this->getAssignablePolicies($request->array('user.policies'));
                     $user->syncPolicies($policies);
                 }
             });
@@ -271,7 +279,12 @@ class UserController extends FleetbaseController
 
             // Assign role if set
             if ($request->filled('user.role')) {
-                $record->assignSingleRole($request->input('user.role'));
+                $role = $this->resolveAssignableRole($request->input('user.role'));
+                if (!$role) {
+                    return response()->error('The selected role is not available for this organisation.', 404);
+                }
+
+                $record->assignSingleRole($role);
             }
 
             // Sync Permissions
@@ -282,7 +295,7 @@ class UserController extends FleetbaseController
 
             // Sync Policies
             if ($request->isArray('user.policies')) {
-                $policies = Policy::whereIn('id', $request->array('user.policies'))->get();
+                $policies = $this->getAssignablePolicies($request->array('user.policies'));
                 $record->syncPolicies($policies);
             }
 
@@ -411,6 +424,51 @@ class UserController extends FleetbaseController
         }
 
         return (string) $incoming === (string) $current;
+    }
+
+    /**
+     * Resolve a role assignable by the active company.
+     */
+    private function resolveAssignableRole(string|Role|null $role, ?string $companyUuid = null): ?Role
+    {
+        $companyUuid ??= session('company');
+
+        if (!$role) {
+            return null;
+        }
+
+        if ($role instanceof Role) {
+            return $this->roleBelongsToCompany($role, $companyUuid) ? $role : null;
+        }
+
+        $query = Role::where(function (Builder $query) use ($role) {
+            $query->where('id', $role)->orWhere('name', $role);
+        });
+
+        $query->where(function (Builder $query) use ($companyUuid) {
+            $query->where('company_uuid', $companyUuid)
+                ->orWhereNull('company_uuid');
+        });
+
+        return $query->first();
+    }
+
+    /**
+     * Resolve policies assignable by the active company.
+     */
+    private function getAssignablePolicies(array $ids)
+    {
+        return Policy::whereIn('id', $ids)
+            ->where(function (Builder $query) {
+                $query->where('company_uuid', session('company'))
+                    ->orWhereNull('company_uuid');
+            })
+            ->get();
+    }
+
+    private function roleBelongsToCompany(Role $role, ?string $companyUuid): bool
+    {
+        return empty($role->company_uuid) || $role->company_uuid === $companyUuid;
     }
 
     /**
@@ -628,6 +686,10 @@ class UserController extends FleetbaseController
             return response()->error('Unable to determine the current organisation.');
         }
 
+        if ($request->filled('user.role_uuid') && !$this->resolveAssignableRole($request->input('user.role_uuid'))) {
+            return response()->error('The selected role is not available for this organisation.', 404);
+        }
+
         // Check if user already exists in the system.
         $user = User::where('email', $email)->whereNull('deleted_at')->first();
 
@@ -656,12 +718,14 @@ class UserController extends FleetbaseController
         // Set user type
         $user->setUserType('user');
 
+        $role = $this->resolveAssignableRole($request->input('user.role_uuid'));
+
         // Assign to user
-        $user->assignCompany($company, $request->input('user.role_uuid'));
+        $user->assignCompany($company, $role ? $role->id : 'Administrator');
 
         // Assign role if set
-        if ($request->filled('user.role_uuid')) {
-            $user->assignSingleRole($request->input('user.role_uuid'));
+        if ($role) {
+            $user->assignSingleRole($role);
         }
 
         if (!Invite::isAlreadySentToJoinCompany($user, $company)) {
@@ -708,6 +772,11 @@ class UserController extends FleetbaseController
             return response()->error('This user has already been invited to join your organisation.');
         }
 
+        $roleIdentifier = $request->input('user.role_uuid') ?? $request->input('user.role');
+        if ($roleIdentifier && !$this->resolveAssignableRole($roleIdentifier)) {
+            return response()->error('The selected role is not available for this organisation.', 404);
+        }
+
         $invitation = Invite::create([
             'company_uuid'    => $company->uuid,
             'created_by_uuid' => session('user'),
@@ -716,7 +785,7 @@ class UserController extends FleetbaseController
             'protocol'        => 'email',
             'recipients'      => [$user->email],
             'reason'          => 'join_company',
-            'meta'            => array_filter(['role_uuid' => $request->input('user.role_uuid') ?? $request->input('user.role')]),
+            'meta'            => array_filter(['role_uuid' => $roleIdentifier]),
             'expires_at'      => now()->addHours(48),
         ]);
 
@@ -740,6 +809,10 @@ class UserController extends FleetbaseController
     {
         $user    = User::where('uuid', $request->input('user'))->first();
         $company = Company::where('uuid', session('company'))->first();
+
+        if (!$user || !$company || !$this->canResendInvitationForCompany($user, $company)) {
+            return response()->error('Unable to resend invitation.', 404);
+        }
 
         // create invitation
         $invitation = Invite::create([
@@ -804,7 +877,8 @@ class UserController extends FleetbaseController
             // Use Company::addUser() so that role assignment is handled in
             // one place. The role stored in the invite meta takes precedence;
             // if none was set the default 'Administrator' role is used.
-            $roleIdentifier = $invite->getMeta('role_uuid', 'Administrator');
+            $role           = $this->resolveAssignableRole($invite->getMeta('role_uuid'), $company->uuid);
+            $roleIdentifier = $role ? $role->id : 'Administrator';
             $companyUser    = $company->addUser($user, $roleIdentifier);
             $user->setRelation('companyUser', $companyUser);
         } else {
@@ -812,9 +886,9 @@ class UserController extends FleetbaseController
             // loaded so that role assignment below can still be applied if
             // the invite carries a role (e.g. re-sent invite with a new role).
             $user->loadCompanyUser();
-            $roleUuid = $invite->getMeta('role_uuid');
-            if ($user->companyUser && $roleUuid) {
-                $user->companyUser->assignSingleRole($roleUuid);
+            $role = $this->resolveAssignableRole($invite->getMeta('role_uuid'), $company->uuid);
+            if ($user->companyUser && $role) {
+                $user->companyUser->assignSingleRole($role);
             }
         }
 
@@ -850,6 +924,19 @@ class UserController extends FleetbaseController
     protected function findCompanyInvite(string $code): ?Invite
     {
         return Invite::where('code', $code)->with(['subject'])->first();
+    }
+
+    private function canResendInvitationForCompany(User $user, Company $company): bool
+    {
+        $isMember = $user->companyUsers()
+            ->where('company_uuid', $company->uuid)
+            ->exists();
+
+        if ($isMember) {
+            return true;
+        }
+
+        return Invite::isAlreadySentToJoinCompany($user, $company);
     }
 
     /**
@@ -965,7 +1052,7 @@ class UserController extends FleetbaseController
             return response()->error('No user to activate', 401);
         }
 
-        $user = User::where('uuid', $id)->first();
+        $user = $this->resolveVisibleUser($id, request());
 
         if (!$user) {
             return response()->error('No user found', 401);
@@ -993,7 +1080,7 @@ class UserController extends FleetbaseController
         }
 
         // get user to remove from company
-        $user = User::where('uuid', $id)->first();
+        $user = $this->resolveVisibleUser($id, request());
 
         if (!$user) {
             return response()->error('No user found', 401);
@@ -1010,7 +1097,7 @@ class UserController extends FleetbaseController
         $userCompanies = $user->companyUsers()->get();
 
         // only a member to one company then delete the user
-        if ($userCompanies->count() === 1) {
+        if ($userCompanies->count() === 1 && $userCompanies->first()?->company_uuid === $company->uuid) {
             $user->delete();
         } else {
             $user->companyUsers()->where('company_uuid', $company->uuid)->delete();

--- a/src/Http/Controllers/Internal/v1/WebhookEndpointController.php
+++ b/src/Http/Controllers/Internal/v1/WebhookEndpointController.php
@@ -3,7 +3,9 @@
 namespace Fleetbase\Http\Controllers\Internal\v1;
 
 use Fleetbase\Http\Controllers\FleetbaseController;
+use Fleetbase\Http\Requests\Internal\WebhookEndpointRequest;
 use Fleetbase\Models\WebhookEndpoint;
+use Fleetbase\Rules\PublicWebhookUrl;
 
 class WebhookEndpointController extends FleetbaseController
 {
@@ -13,6 +15,20 @@ class WebhookEndpointController extends FleetbaseController
      * @var string
      */
     public $resource = 'webhook_endpoint';
+
+    /**
+     * Create webhook endpoint request.
+     *
+     * @var WebhookEndpointRequest
+     */
+    public $createRequest = WebhookEndpointRequest::class;
+
+    /**
+     * Update webhook endpoint request.
+     *
+     * @var WebhookEndpointRequest
+     */
+    public $updateRequest = WebhookEndpointRequest::class;
 
     /**
      * The service which this controller belongs to.
@@ -32,9 +48,14 @@ class WebhookEndpointController extends FleetbaseController
             return response()->error('No webhook to enable', 401);
         }
 
-        $webhook = WebhookEndpoint::where('uuid', $id)->first();
+        $webhook = WebhookEndpoint::where('uuid', $id)->where('company_uuid', session('company'))->first();
         if (!$webhook) {
             return response()->error('No webhook found', 401);
+        }
+
+        $urlRule = new PublicWebhookUrl();
+        if (!$urlRule->passes('url', $webhook->url)) {
+            return response()->error($urlRule->message(), 422);
         }
 
         $webhook->enable();
@@ -56,7 +77,7 @@ class WebhookEndpointController extends FleetbaseController
             return response()->error('No webhook to disable', 401);
         }
 
-        $webhook = WebhookEndpoint::where('uuid', $id)->first();
+        $webhook = WebhookEndpoint::where('uuid', $id)->where('company_uuid', session('company'))->first();
         if (!$webhook) {
             return response()->error('No webhook found', 401);
         }

--- a/src/Http/Middleware/AuthenticatePlatformApiToken.php
+++ b/src/Http/Middleware/AuthenticatePlatformApiToken.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Fleetbase\Http\Middleware;
+
+use Fleetbase\Support\PlatformApi;
+use Illuminate\Http\Request;
+
+class AuthenticatePlatformApiToken
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param Request $request
+     */
+    public function handle($request, \Closure $next)
+    {
+        if (!PlatformApi::validateToken($request->bearerToken())) {
+            return response()->error('Invalid platform API token.', 401);
+        }
+
+        PlatformApi::markUsed();
+
+        return $next($request);
+    }
+}

--- a/src/Http/Requests/Internal/ChangeCurrentUserEmailRequest.php
+++ b/src/Http/Requests/Internal/ChangeCurrentUserEmailRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Fleetbase\Http\Requests\Internal;
+
+use Fleetbase\Http\Requests\FleetbaseRequest;
+use Fleetbase\Rules\EmailDomainExcluded;
+use Illuminate\Validation\Rule;
+
+class ChangeCurrentUserEmailRequest extends FleetbaseRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $user = $this->user();
+
+        return [
+            'email'    => [
+                'required',
+                'email',
+                new EmailDomainExcluded(),
+                Rule::unique('users', 'email')->whereNull('deleted_at')->ignore($user?->uuid, 'uuid'),
+            ],
+            'password' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @param \Illuminate\Validation\Validator $validator
+     *
+     * @return void
+     */
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $user     = $this->user();
+            $password = $this->input('password');
+
+            if (!$user || !is_string($password) || !$user->checkPassword($password)) {
+                $validator->errors()->add('password', 'The current password provided is invalid.');
+            }
+        });
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'email.required'    => 'A new email address is required.',
+            'email.email'       => 'You must enter a valid email address.',
+            'email.unique'      => 'An account with this email address already exists.',
+            'password.required' => 'The current password is required.',
+            'password.string'   => 'The current password must be a string.',
+        ];
+    }
+}

--- a/src/Http/Requests/Internal/ChangeUserEmailRequest.php
+++ b/src/Http/Requests/Internal/ChangeUserEmailRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Fleetbase\Http\Requests\Internal;
+
+use Fleetbase\Http\Requests\FleetbaseRequest;
+use Fleetbase\Rules\EmailDomainExcluded;
+use Illuminate\Validation\Rule;
+
+class ChangeUserEmailRequest extends FleetbaseRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return session('company');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => ['required', 'email', new EmailDomainExcluded(), Rule::unique('users', 'email')->whereNull('deleted_at')],
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'email.required' => 'A new email address is required.',
+            'email.email'    => 'You must enter a valid email address.',
+            'email.unique'   => 'An account with this email address already exists.',
+        ];
+    }
+}

--- a/src/Http/Requests/Internal/UserForgotPasswordRequest.php
+++ b/src/Http/Requests/Internal/UserForgotPasswordRequest.php
@@ -24,7 +24,7 @@ class UserForgotPasswordRequest extends FleetbaseRequest
     public function rules()
     {
         return [
-            'email' => ['required', 'exists:users,email'],
+            'email' => ['required', 'email'],
         ];
     }
 }

--- a/src/Http/Requests/Internal/WebhookEndpointRequest.php
+++ b/src/Http/Requests/Internal/WebhookEndpointRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Fleetbase\Http\Requests\Internal;
+
+use Fleetbase\Http\Requests\FleetbaseRequest;
+use Fleetbase\Rules\PublicWebhookUrl;
+
+class WebhookEndpointRequest extends FleetbaseRequest
+{
+    public function authorize()
+    {
+        return session('company');
+    }
+
+    public function rules()
+    {
+        return [
+            'url' => [$this->isMethod('post') ? 'required' : 'sometimes', 'string', 'url', new PublicWebhookUrl()],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'url.required' => 'A webhook URL is required.',
+            'url.url'      => 'The webhook URL must be a valid URL.',
+        ];
+    }
+}

--- a/src/Http/Requests/UpdateUserRequest.php
+++ b/src/Http/Requests/UpdateUserRequest.php
@@ -2,7 +2,6 @@
 
 namespace Fleetbase\Http\Requests;
 
-use Fleetbase\Rules\EmailDomainExcluded;
 use Fleetbase\Rules\ValidPhoneNumber;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
@@ -41,20 +40,6 @@ class UpdateUserRequest extends FleetbaseRequest
         return [
             'name'  => ['sometimes', 'required', 'string', 'min:2', 'max:100'],
 
-            // Email must be a valid address, must not be empty, and must remain
-            // unique across non-deleted users — ignoring the current user's own row.
-            'email' => [
-                'sometimes',
-                'required',
-                'string',
-                'email',
-                'max:255',
-                Rule::unique('users', 'email')
-                    ->ignore($userId, 'uuid')
-                    ->whereNull('deleted_at'),
-                new EmailDomainExcluded(),
-            ],
-
             // Phone is optional (some user types may not have one), but if it is
             // supplied it must be a valid E.164 number and must remain unique.
             // `nullable` allows explicit null to clear the field; `required_with`
@@ -80,9 +65,6 @@ class UpdateUserRequest extends FleetbaseRequest
         return [
             'name.required'   => 'Name cannot be empty.',
             'name.min'        => 'Name must be at least 2 characters.',
-            'email.required'  => 'Email address cannot be empty.',
-            'email.email'     => 'A valid email address is required.',
-            'email.unique'    => 'An account with this email address already exists.',
             'phone.unique'    => 'An account with this phone number already exists.',
         ];
     }

--- a/src/Http/Resources/AuthOrganization.php
+++ b/src/Http/Resources/AuthOrganization.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Fleetbase\Http\Resources;
+
+use Fleetbase\Models\Setting;
+use Fleetbase\Support\Utils;
+
+class AuthOrganization extends FleetbaseResource
+{
+    protected function getBillingStatus(): ?string
+    {
+        if (!class_exists('\\Fleetbase\\Billing\\Models\\Subscription')) {
+            return $this->plan ? 'legacy' : null;
+        }
+
+        $subscriptionClass = '\\Fleetbase\\Billing\\Models\\Subscription';
+        $subscription      = $subscriptionClass::where('company_uuid', $this->uuid)->latest('created_at')->first();
+
+        return $subscription?->payment_gateway_status ?? ($this->plan ? 'legacy' : null);
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id'                   => $this->id,
+            'uuid'                 => $this->uuid,
+            'public_id'            => $this->public_id,
+            'name'                 => $this->name,
+            'description'          => $this->description,
+            'phone'                => $this->phone,
+            'type'                 => $this->type,
+            'users_count'          => $this->users_count,
+            'timezone'             => $this->timezone,
+            'country'              => $this->country,
+            'currency'             => $this->currency,
+            'plan'                 => $this->plan,
+            'trial_ends_at'        => $this->trial_ends_at,
+            'logo_url'             => $this->logo_url,
+            'backdrop_url'         => $this->backdrop_url,
+            'branding'             => Setting::getBranding(),
+            'options'              => $this->options ?? Utils::createObject([]),
+            'owner'                => $this->owner ? [
+                'uuid'  => $this->owner->uuid,
+                'name'  => $this->owner->name,
+                'email' => $this->owner->email,
+            ] : null,
+            'slug'                 => $this->slug,
+            'status'               => $this->status,
+            'billing_status'       => $this->getBillingStatus(),
+            'onboarding_completed' => $this->onboarding_completed_at !== null,
+            'joined_at'            => $this->joined_at,
+            'updated_at'           => $this->updated_at,
+            'created_at'           => $this->created_at,
+        ];
+    }
+}

--- a/src/Http/Resources/FleetbaseResourceCollection.php
+++ b/src/Http/Resources/FleetbaseResourceCollection.php
@@ -3,6 +3,7 @@
 namespace Fleetbase\Http\Resources;
 
 use Fleetbase\Http\Resources\Json\FleetbasePaginatedResourceResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Resources\Json\ResourceCollection;
 use Illuminate\Support\Arr;
 
@@ -78,7 +79,7 @@ class FleetbaseResourceCollection extends ResourceCollection
     {
         return $this->collection->map(function ($item) use ($request) {
             // If the item is already a resource and has ->without(), use it.
-            if (is_object($item) && method_exists($item, 'toArray')) {
+            if ($item instanceof JsonResource) {
                 if (method_exists($item, 'without')) {
                     /** @var object $item */
                     $array = $item->without($this->excluded)->toArray($request);
@@ -92,7 +93,7 @@ class FleetbaseResourceCollection extends ResourceCollection
                 return $this->applyArrayExclusions($array);
             }
 
-            // If $collects is set, wrap the raw item in the resource class.
+            // If $collects is set, wrap raw models/arrays in the resource class.
             if (is_string($this->collects) && class_exists($this->collects)) {
                 $resource = new $this->collects($item);
 
@@ -104,6 +105,12 @@ class FleetbaseResourceCollection extends ResourceCollection
                 }
 
                 return $array;
+            }
+
+            if (is_object($item) && method_exists($item, 'toArray')) {
+                $array = $item->toArray();
+
+                return $this->applyArrayExclusions($array);
             }
 
             // Fallback: treat as plain array/object and filter keys.

--- a/src/Models/TemplateQuery.php
+++ b/src/Models/TemplateQuery.php
@@ -3,12 +3,15 @@
 namespace Fleetbase\Models;
 
 use Fleetbase\Casts\Json;
+use Fleetbase\Services\TemplateRenderService;
 use Fleetbase\Traits\HasApiModelBehavior;
 use Fleetbase\Traits\HasPublicId;
 use Fleetbase\Traits\HasUuid;
 use Fleetbase\Traits\TracksApiCredential;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Schema;
 
 class TemplateQuery extends Model
 {
@@ -102,15 +105,26 @@ class TemplateQuery extends Model
     {
         $modelClass = $this->model_type;
 
-        if (!class_exists($modelClass)) {
+        if (!TemplateRenderService::isTemplateQueryModelAllowed($modelClass) || !class_exists($modelClass)) {
+            return collect();
+        }
+
+        $model = new $modelClass();
+        if (!$model instanceof EloquentModel) {
             return collect();
         }
 
         $query = $modelClass::query();
 
-        // Apply company scope if the model supports it
-        if (isset((new $modelClass())->fillable) && in_array('company_uuid', (new $modelClass())->getFillable())) {
-            $query->where('company_uuid', $this->company_uuid);
+        if ($this->modelHasCompanyColumn($model)) {
+            $companyUuid = $this->company_uuid ?: session('company');
+            if (empty($companyUuid)) {
+                return collect();
+            }
+
+            $query->where($model->qualifyColumn('company_uuid'), $companyUuid);
+        } elseif (!TemplateRenderService::isTemplateQueryModelGloballyQueryable($modelClass)) {
+            return collect();
         }
 
         // Apply filter conditions
@@ -168,5 +182,12 @@ class TemplateQuery extends Model
         }
 
         return $query->get();
+    }
+
+    protected function modelHasCompanyColumn(EloquentModel $model): bool
+    {
+        $connection = $model->getConnectionName() ?: config('database.default');
+
+        return Schema::connection($connection)->hasColumn($model->getTable(), 'company_uuid');
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -990,6 +990,7 @@ class User extends Authenticatable
     {
         $verifyCode = VerificationCode::where('subject_uuid', $this->uuid)
             ->whereIn('for', $types)
+            ->where('status', 'active')
             ->where('code', $code)
             ->firstOrFail();
 

--- a/src/Models/VerificationCode.php
+++ b/src/Models/VerificationCode.php
@@ -11,6 +11,7 @@ use Fleetbase\Traits\HasMetaAttributes;
 use Fleetbase\Traits\HasSubject;
 use Fleetbase\Traits\HasUuid;
 use Fleetbase\Twilio\Support\Laravel\Facade as Twilio;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Mail;
 
@@ -122,6 +123,7 @@ class VerificationCode extends Model
         $verificationCode             = static::generateFor($subject, $for, false);
         $verificationCode->expires_at = $expireAfter === null ? Carbon::now()->addHour() : $expireAfter;
         $verificationCode->meta       = data_get($options, 'meta', []);
+        $verificationCode->status     = data_get($options, 'status', 'active');
         $verificationCode->save();
 
         if (isset($subject->email)) {
@@ -141,8 +143,8 @@ class VerificationCode extends Model
             $mail = new VerificationMail($verificationCode, $content);
 
             // Apply any additional Mail facade parameters
-            $mailer = Mail::to($subject);
-            foreach ($options as $key => $value) {
+            $mailer = Mail::to(data_get($options, 'to', $subject));
+            foreach (Arr::except($options, ['content', 'expireAfter', 'messageCallback', 'meta', 'status', 'subject', 'to']) as $key => $value) {
                 if (method_exists($mailer, $key)) {
                     $mailer->$key($value);
                 }

--- a/src/Notifications/UserEmailChange.php
+++ b/src/Notifications/UserEmailChange.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Fleetbase\Notifications;
+
+use Fleetbase\Models\VerificationCode;
+use Fleetbase\Support\Utils;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class UserEmailChange extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Instance of the verification code for the email change.
+     */
+    public ?VerificationCode $verificationCode;
+
+    /**
+     * The URL where the user can confirm the email change.
+     */
+    public string $url;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(?VerificationCode $verificationCode)
+    {
+        $this->verificationCode = $verificationCode;
+        $this->url              = Utils::consoleUrl('auth/confirm-email-change/' . $verificationCode->uuid, ['code' => $verificationCode->code]);
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @return MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $user     = $this->verificationCode->subject;
+        $oldEmail = data_get($this->verificationCode->meta, 'old_email');
+        $newEmail = data_get($this->verificationCode->meta, 'new_email');
+
+        return (new MailMessage())
+            ->subject('Confirm your ' . config('app.name') . ' email change')
+            ->greeting('Hello, ' . data_get($user, 'name', 'there'))
+            ->line('An email change was requested for your ' . config('app.name') . ' account.')
+            ->line('Current login email: ' . $oldEmail)
+            ->line('New login email: ' . $newEmail)
+            ->line('Confirm this change only if you expected this email. This address will become your login email after confirmation.')
+            ->action('Confirm Email Change', $this->url)
+            ->line('If the button does not work, use this confirmation code: ' . $this->verificationCode->code)
+            ->line('If you did not request this change, you can ignore this email.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            'code' => $this->verificationCode->code,
+        ];
+    }
+}

--- a/src/Observers/CompanyObserver.php
+++ b/src/Observers/CompanyObserver.php
@@ -19,6 +19,7 @@ class CompanyObserver
 
         foreach ($company->users as $user) {
             Cache::forget("user_organizations_{$user->uuid}");
+            Cache::forget("user_organizations_v2_{$user->uuid}");
         }
     }
 

--- a/src/Observers/UserObserver.php
+++ b/src/Observers/UserObserver.php
@@ -63,7 +63,7 @@ class UserObserver
      */
     private function invalidateOrganizationsCache(User $user): void
     {
-        $cacheKey = "user_organizations_{$user->uuid}";
-        Cache::forget($cacheKey);
+        Cache::forget("user_organizations_{$user->uuid}");
+        Cache::forget("user_organizations_v2_{$user->uuid}");
     }
 }

--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -68,6 +68,11 @@ class CoreServiceProvider extends ServiceProvider
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \Fleetbase\Http\Middleware\LogApiRequests::class,
         ],
+        'fleetbase.platform-api' => [
+            \Fleetbase\Http\Middleware\ThrottleRequests::class,
+            \Fleetbase\Http\Middleware\AuthenticatePlatformApiToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
     ];
 
     /**

--- a/src/Rules/PublicWebhookUrl.php
+++ b/src/Rules/PublicWebhookUrl.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Fleetbase\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class PublicWebhookUrl implements Rule
+{
+    protected string $message = 'The :attribute must be a public HTTP or HTTPS URL.';
+
+    public function passes($attribute, $value): bool
+    {
+        if (!is_string($value) || !filter_var($value, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        $parts  = parse_url($value);
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host   = strtolower(trim((string) ($parts['host'] ?? ''), '[]'));
+
+        if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return false;
+        }
+
+        if ($this->isBlockedHostname($host)) {
+            return false;
+        }
+
+        $addresses = $this->resolveHost($host);
+
+        foreach ($addresses as $address) {
+            if ($this->isBlockedIp($address)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    protected function isBlockedHostname(string $host): bool
+    {
+        return $host === 'localhost'
+            || str_ends_with($host, '.localhost')
+            || $host === 'metadata.google.internal'
+            || $host === 'metadata'
+            || str_ends_with($host, '.internal');
+    }
+
+    protected function resolveHost(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return [$host];
+        }
+
+        $addresses = [];
+        $records   = @dns_get_record($host, DNS_A + DNS_AAAA);
+
+        if (is_array($records)) {
+            foreach ($records as $record) {
+                if (isset($record['ip'])) {
+                    $addresses[] = $record['ip'];
+                }
+
+                if (isset($record['ipv6'])) {
+                    $addresses[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return array_values(array_unique(array_filter($addresses)));
+    }
+
+    protected function isBlockedIp(string $ip): bool
+    {
+        if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+            return true;
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            foreach ($this->blockedIpv4Ranges() as $range) {
+                if ($this->ipv4InCidr($ip, $range)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    protected function blockedIpv4Ranges(): array
+    {
+        return [
+            '0.0.0.0/8',
+            '10.0.0.0/8',
+            '100.64.0.0/10',
+            '127.0.0.0/8',
+            '169.254.0.0/16',
+            '172.16.0.0/12',
+            '192.0.0.0/24',
+            '192.0.2.0/24',
+            '192.168.0.0/16',
+            '198.18.0.0/15',
+            '198.51.100.0/24',
+            '203.0.113.0/24',
+            '224.0.0.0/4',
+            '240.0.0.0/4',
+        ];
+    }
+
+    protected function ipv4InCidr(string $ip, string $cidr): bool
+    {
+        [$subnet, $bits] = explode('/', $cidr);
+
+        $ipLong     = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+
+        if ($ipLong === false || $subnetLong === false) {
+            return false;
+        }
+
+        $mask = -1 << (32 - (int) $bits);
+
+        return ($ipLong & $mask) === ($subnetLong & $mask);
+    }
+}

--- a/src/Services/TemplateRenderService.php
+++ b/src/Services/TemplateRenderService.php
@@ -55,6 +55,41 @@ class TemplateRenderService
     }
 
     /**
+     * Return model classes that templates may execute as query data sources.
+     */
+    public static function getTemplateQueryModels(): array
+    {
+        $contextModels = collect(static::$contextTypes)
+            ->pluck('model')
+            ->filter()
+            ->values()
+            ->all();
+
+        return collect($contextModels)
+            ->merge((array) config('fleetbase.template_query_models', []))
+            ->filter(fn ($modelClass) => is_string($modelClass) && is_subclass_of($modelClass, Model::class))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Determine whether a model class is approved for template query execution.
+     */
+    public static function isTemplateQueryModelAllowed(?string $modelClass): bool
+    {
+        return is_string($modelClass) && in_array($modelClass, static::getTemplateQueryModels(), true);
+    }
+
+    /**
+     * Determine whether an approved model without company_uuid may be queried.
+     */
+    public static function isTemplateQueryModelGloballyQueryable(string $modelClass): bool
+    {
+        return in_array($modelClass, (array) config('fleetbase.template_global_query_models', []), true);
+    }
+
+    /**
      * Return all registered context type schemas.
      */
     public function getContextSchemas(): array

--- a/src/Support/PlatformApi.php
+++ b/src/Support/PlatformApi.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Fleetbase\Support;
+
+use Fleetbase\Models\Setting;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class PlatformApi
+{
+    public const TOKEN_HASH_KEY       = 'platform_api.token_hash';
+    public const TOKEN_ROTATED_AT_KEY = 'platform_api.token_rotated_at';
+    public const TOKEN_LAST_USED_KEY  = 'platform_api.token_last_used_at';
+
+    public static function generateToken(): string
+    {
+        return 'flb_platform_' . Str::random(64);
+    }
+
+    public static function rotateToken(): string
+    {
+        $token = static::generateToken();
+        $now   = Carbon::now()->toISOString();
+
+        Setting::configureSystem(static::TOKEN_HASH_KEY, Hash::make($token));
+        Setting::configureSystem(static::TOKEN_ROTATED_AT_KEY, $now);
+        Setting::configureSystem(static::TOKEN_LAST_USED_KEY, null);
+
+        return $token;
+    }
+
+    public static function revokeToken(): void
+    {
+        Setting::configureSystem(static::TOKEN_HASH_KEY, null);
+        Setting::configureSystem(static::TOKEN_ROTATED_AT_KEY, null);
+        Setting::configureSystem(static::TOKEN_LAST_USED_KEY, null);
+    }
+
+    public static function isConfigured(): bool
+    {
+        return is_string(static::tokenHash()) && static::tokenHash() !== '';
+    }
+
+    public static function validateToken(?string $token): bool
+    {
+        $hash = static::tokenHash();
+
+        return is_string($token) && $token !== '' && is_string($hash) && $hash !== '' && Hash::check($token, $hash);
+    }
+
+    public static function markUsed(): void
+    {
+        Setting::configureSystem(static::TOKEN_LAST_USED_KEY, Carbon::now()->toISOString());
+    }
+
+    public static function status(): array
+    {
+        return [
+            'configured'   => static::isConfigured(),
+            'rotated_at'   => Setting::system(static::TOKEN_ROTATED_AT_KEY),
+            'last_used_at' => Setting::system(static::TOKEN_LAST_USED_KEY),
+        ];
+    }
+
+    public static function tokenHash(): ?string
+    {
+        $hash = Setting::system(static::TOKEN_HASH_KEY);
+
+        return is_string($hash) ? $hash : null;
+    }
+}

--- a/src/Traits/HasApiModelBehavior.php
+++ b/src/Traits/HasApiModelBehavior.php
@@ -755,7 +755,7 @@ trait HasApiModelBehavior
      *
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function getById($id, ?callable $queryCallback = null, Request $request)
+    public function getById($id, ?callable $queryCallback, Request $request)
     {
         $builder = $this->where(function ($q) use ($id) {
             $publicIdColumn = $this->getQualifiedPublicId();

--- a/src/routes.php
+++ b/src/routes.php
@@ -30,6 +30,13 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
         */
         $router->prefix('v1')
             ->namespace('Api\v1')
+            ->middleware([Fleetbase\Http\Middleware\ThrottleRequests::class])
+            ->group(function ($router) {
+                $router->get('organizations', 'OrganizationController@listOrganizations');
+            });
+
+        $router->prefix('v1')
+            ->namespace('Api\v1')
             ->middleware(['fleetbase.api'])
             ->group(function ($router) {
                 $router->group(
@@ -262,6 +269,8 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                                     $router->patch('activate/{id}', $controller('activate'));
                                     $router->patch('verify/{id}', $controller('verify'));
                                     $router->delete('remove-from-company/{id}', $controller('removeFromCompany'));
+                                    $router->post('change-email', $controller('changeCurrentUserEmail'));
+                                    $router->post('{id}/change-email', $controller('changeEmail'));
                                     $router->post('invite-user', $controller('inviteUser'));
                                     $router->post('resend-invite', $controller('resendInvitation'));
                                     $router->post('set-password', $controller('setCurrentUserPassword'));

--- a/src/routes.php
+++ b/src/routes.php
@@ -30,7 +30,7 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
         */
         $router->prefix('v1')
             ->namespace('Api\v1')
-            ->middleware([Fleetbase\Http\Middleware\ThrottleRequests::class])
+            ->middleware(['fleetbase.platform-api'])
             ->group(function ($router) {
                 $router->get('organizations', 'OrganizationController@listOrganizations');
             });
@@ -200,6 +200,9 @@ Route::prefix(config('fleetbase.api.routing.prefix', '/'))->namespace('Fleetbase
                                 );
                                 $router->fleetbaseRoutes('settings', null, [], function ($router, $controller) {
                                     $router->get('overview', $controller('adminOverview'));
+                                    $router->get('platform-api-token', $controller('getPlatformApiToken'));
+                                    $router->post('platform-api-token', $controller('rotatePlatformApiToken'));
+                                    $router->delete('platform-api-token', $controller('revokePlatformApiToken'));
                                     $router->get('filesystem-config', $controller('getFilesystemConfig'));
                                     $router->post('filesystem-config', $controller('saveFilesystemConfig'));
                                     $router->post('test-filesystem-config', $controller('testFilesystemConfig'));

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Foundation\Auth\Access {
+    if (!trait_exists(AuthorizesRequests::class)) {
+        trait AuthorizesRequests
+        {
+        }
+    }
+}
+
+namespace Illuminate\Foundation\Bus {
+    if (!trait_exists(DispatchesJobs::class)) {
+        trait DispatchesJobs
+        {
+        }
+    }
+}
+
+namespace Illuminate\Foundation\Validation {
+    if (!trait_exists(ValidatesRequests::class)) {
+        trait ValidatesRequests
+        {
+        }
+    }
+}
+
+namespace Illuminate\Foundation\Http {
+    if (!class_exists(FormRequest::class)) {
+        class FormRequest extends \Illuminate\Http\Request
+        {
+        }
+    }
+}
+
+namespace {
+    use Illuminate\Container\Container;
+    use Illuminate\Http\JsonResponse;
+
+    if (!function_exists('config')) {
+        function config($key = null, $default = null)
+        {
+            $config = Container::getInstance()->make('config');
+
+            if ($key === null) {
+                return $config;
+            }
+
+            return $config->get($key, $default);
+        }
+    }
+
+    if (!function_exists('response')) {
+        function response(): AcceptCompanyInviteTestResponseFactory
+        {
+            return new AcceptCompanyInviteTestResponseFactory();
+        }
+    }
+
+    class AcceptCompanyInviteTestResponseFactory
+    {
+        public function error($error, int $statusCode = 400, ?array $data = []): JsonResponse
+        {
+            return $this->json(
+                array_merge([
+                    'errors' => is_array($error) ? $error : [$error],
+                ], $data),
+                $statusCode
+            );
+        }
+
+        public function json(array $data, int $statusCode = 200): JsonResponse
+        {
+            return new JsonResponse($data, $statusCode);
+        }
+    }
+}

--- a/tests/Unit/AcceptCompanyInviteTest.php
+++ b/tests/Unit/AcceptCompanyInviteTest.php
@@ -1,59 +1,9 @@
 <?php
 
-namespace Illuminate\Foundation\Auth\Access {
-    trait AuthorizesRequests
-    {
-    }
-}
-
-namespace Illuminate\Foundation\Bus {
-    trait DispatchesJobs
-    {
-    }
-}
-
-namespace Illuminate\Foundation\Validation {
-    trait ValidatesRequests
-    {
-    }
-}
-
-namespace Illuminate\Foundation\Http {
-    class FormRequest extends \Illuminate\Http\Request
-    {
-    }
-}
-
 namespace {
     use Fleetbase\Http\Controllers\Internal\v1\UserController;
     use Fleetbase\Http\Requests\Internal\AcceptCompanyInvite;
     use Fleetbase\Models\Invite;
-    use Illuminate\Http\JsonResponse;
-
-    if (!function_exists('response')) {
-        function response(): AcceptCompanyInviteTestResponseFactory
-        {
-            return new AcceptCompanyInviteTestResponseFactory();
-        }
-    }
-
-    class AcceptCompanyInviteTestResponseFactory
-    {
-        public function error($error, int $statusCode = 400, ?array $data = []): JsonResponse
-        {
-            return $this->json(
-                array_merge([
-                    'errors' => is_array($error) ? $error : [$error],
-                ], $data),
-                $statusCode
-            );
-        }
-
-        public function json(array $data, int $statusCode = 200): JsonResponse
-        {
-            return new JsonResponse($data, $statusCode);
-        }
-    }
 
     class AcceptCompanyInviteTestController extends UserController
     {

--- a/tests/Unit/OrganizationControllerTest.php
+++ b/tests/Unit/OrganizationControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Foundation\Auth\Access {
+    if (!trait_exists(AuthorizesRequests::class)) {
+        trait AuthorizesRequests
+        {
+        }
+    }
+}
+
+namespace Illuminate\Foundation\Bus {
+    if (!trait_exists(DispatchesJobs::class)) {
+        trait DispatchesJobs
+        {
+        }
+    }
+}
+
+namespace Illuminate\Foundation\Validation {
+    if (!trait_exists(ValidatesRequests::class)) {
+        trait ValidatesRequests
+        {
+        }
+    }
+}
+
+namespace {
+    use Fleetbase\Http\Controllers\Api\v1\OrganizationController;
+
+    test('public organizations listing supports name query filtering', function () {
+        $reflection = new ReflectionClass(OrganizationController::class);
+        $source     = file_get_contents($reflection->getFileName());
+
+        expect($source)->toContain("\$searchQuery = trim((string) \$request->input('query', ''));")
+            ->and($source)->toContain("->when(\$searchQuery !== ''")
+            ->and($source)->toContain("->where('companies.name', 'LIKE', '%' . \$searchQuery . '%')")
+            ->and($source)->toContain("->whereHas('users')")
+            ->and($source)->toContain("->select(['name', 'public_id'])");
+    });
+}

--- a/tests/Unit/Reporting/ComputedColumnValidatorTest.php
+++ b/tests/Unit/Reporting/ComputedColumnValidatorTest.php
@@ -7,7 +7,7 @@ use Fleetbase\Support\Reporting\ReportSchemaRegistry;
 use Fleetbase\Support\Reporting\Schema\Column;
 use Fleetbase\Support\Reporting\Schema\Relationship;
 use Fleetbase\Support\Reporting\Schema\Table;
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ComputedColumnValidatorTest extends TestCase
 {
@@ -18,8 +18,8 @@ class ComputedColumnValidatorTest extends TestCase
     {
         parent::setUp();
 
-        // Create a mock registry with a test table
         $this->registry = new ReportSchemaRegistry();
+        $this->registry->setCacheEnabled(false);
 
         $testTable = Table::make('test_table')
             ->label('Test Table')

--- a/tests/Unit/SecurityFindingsTest.php
+++ b/tests/Unit/SecurityFindingsTest.php
@@ -25,10 +25,28 @@ namespace Illuminate\Foundation\Http {
 }
 
 namespace {
+    use Fleetbase\Http\Controllers\Internal\v1\ApiCredentialController;
+    use Fleetbase\Http\Controllers\Internal\v1\ChatChannelController;
     use Fleetbase\Http\Controllers\Internal\v1\CompanyController;
+    use Fleetbase\Http\Controllers\Internal\v1\FileController;
+    use Fleetbase\Http\Controllers\Internal\v1\NotificationController;
+    use Fleetbase\Http\Controllers\Internal\v1\PolicyController;
+    use Fleetbase\Http\Controllers\Internal\v1\ReportController;
+    use Fleetbase\Http\Controllers\Internal\v1\RoleController;
+    use Fleetbase\Http\Controllers\Internal\v1\ScheduleExceptionController;
+    use Fleetbase\Http\Controllers\Internal\v1\ScheduleTemplateController;
+    use Fleetbase\Http\Controllers\Internal\v1\TemplateController;
+    use Fleetbase\Http\Controllers\Internal\v1\UserController;
     use Fleetbase\Http\Requests\Internal\UserForgotPasswordRequest;
     use Fleetbase\Http\Requests\Internal\WebhookEndpointRequest;
     use Fleetbase\Rules\PublicWebhookUrl;
+
+    function controller_source(string $class): string
+    {
+        $reflection = new ReflectionClass($class);
+
+        return file_get_contents($reflection->getFileName());
+    }
 
     test('forgot password request does not expose a registered email oracle', function () {
         $rules = (new UserForgotPasswordRequest())->rules();
@@ -43,6 +61,109 @@ namespace {
         expect($reflection->getMethod('findRecord')->getDeclaringClass()->getName())->toBe(CompanyController::class)
             ->and($reflection->getMethod('updateRecord')->getDeclaringClass()->getName())->toBe(CompanyController::class)
             ->and($reflection->getMethod('deleteRecord')->getDeclaringClass()->getName())->toBe(CompanyController::class);
+    });
+
+    test('api credential roll resolves credentials inside the active company', function () {
+        $source = controller_source(ApiCredentialController::class);
+
+        expect($source)->toContain("ApiCredential::where('uuid', \$id)")
+            ->and($source)->toContain("->where('company_uuid', session('company'))")
+            ->and($source)->not->toContain('ApiCredential::find($id)');
+    });
+
+    test('policy deletion resolves only organization managed policies inside the active company', function () {
+        $source = controller_source(PolicyController::class);
+
+        expect($source)->toContain("Policy::where('id', \$id)")
+            ->and($source)->toContain("->where('company_uuid', session('company'))")
+            ->and($source)->not->toContain('Policy::find($id)');
+    });
+
+    test('notification mutations are scoped to the authenticated user', function () {
+        $source = controller_source(NotificationController::class);
+
+        expect($source)->toContain("Notification::where('notifiable_id', session('user'))")
+            ->and($source)->toContain("->where('notifiable_type', User::class)")
+            ->and($source)->toContain('public function deleteRecord($id, Request $request)')
+            ->and($source)->not->toContain("Notification::where('id', \$id)->first()")
+            ->and($source)->not->toContain('Notification::find($notificationId)')
+            ->and($source)->not->toContain('Notification::whereIn(\'id\', $notifications)->delete()');
+    });
+
+    test('company ownership transfer and leave bind to session company and authenticated user', function () {
+        $source = controller_source(CompanyController::class);
+
+        expect($source)->toContain("\$sessionCompany = session('company')")
+            ->and($source)->toContain("Company::where('uuid', \$sessionCompany)->first()")
+            ->and($source)->toContain('Only the organization owner can transfer ownership.')
+            ->and($source)->toContain('Select a different organization member before leaving.')
+            ->and($source)->toContain('Transfer ownership before leaving the organization.')
+            ->and($source)->not->toContain('Str::isUuid($currentUserId) ? User::where')
+            ->and($source)->not->toContain("Company::where('uuid', \$companyId)->first()");
+    });
+
+    test('user management mutations resolve users and iam records inside the active company', function () {
+        $source = controller_source(UserController::class);
+
+        expect($source)->toContain('$this->resolveVisibleUser($id, request())')
+            ->and($source)->toContain('$this->resolveAssignableRole(')
+            ->and($source)->toContain('$this->getAssignablePolicies(')
+            ->and($source)->toContain('$userCompanies->first()?->company_uuid === $company->uuid')
+            ->and($source)->not->toContain('$user = User::where(\'uuid\', $id)->first();');
+    });
+
+    test('role policy attachment is limited to active company or managed policies', function () {
+        $source = controller_source(RoleController::class);
+
+        expect($source)->toContain('$this->getAssignablePolicies(')
+            ->and($source)->toContain("->where('company_uuid', session('company'))")
+            ->and($source)->toContain('->orWhereNull(\'company_uuid\')')
+            ->and($source)->not->toContain('Policy::whereIn(\'id\', $request->array(\'role.policies\'))->get()');
+    });
+
+    test('file download resolves files inside the active company and uses stored disk', function () {
+        $source = controller_source(FileController::class);
+
+        expect($source)->toContain("->where('company_uuid', session('company'))")
+            ->and($source)->toContain('$disk     = $file->disk ?: config(\'filesystems.default\');')
+            ->and($source)->not->toContain("\$disk     = \$request->input('disk'");
+    });
+
+    test('scheduling custom actions are scoped to the active company', function () {
+        $exceptionSource = controller_source(ScheduleExceptionController::class);
+        $templateSource  = controller_source(ScheduleTemplateController::class);
+
+        expect($exceptionSource)->toContain('scheduleExceptionQuery')
+            ->and($exceptionSource)->toContain("ScheduleException::where('company_uuid', session('company'))")
+            ->and($templateSource)->toContain('scheduleTemplateQuery')
+            ->and($templateSource)->toContain('scheduleQuery')
+            ->and($templateSource)->toContain("ScheduleTemplate::where('company_uuid', session('company'))")
+            ->and($templateSource)->toContain("Schedule::where('company_uuid', session('company'))");
+    });
+
+    test('template and report custom actions are scoped to active company subjects', function () {
+        $templateSource = controller_source(TemplateController::class);
+        $reportSource   = controller_source(ReportController::class);
+
+        expect($templateSource)->toContain('templateQuery')
+            ->and($templateSource)->toContain("Template::where('company_uuid', session('company'))")
+            ->and($templateSource)->toContain('resolveTemplateSubject')
+            ->and($templateSource)->toContain('isAllowedSubjectModel')
+            ->and($templateSource)->toContain('modelHasCompanyColumn')
+            ->and($templateSource)->not->toContain('$subjectType::where(\'uuid\', $subjectId)')
+            ->and($reportSource)->toContain('reportQuery')
+            ->and($reportSource)->toContain("->where('company_uuid', session('company'))");
+    });
+
+    test('chat custom actions bind users and channels to active company membership', function () {
+        $source = controller_source(ChatChannelController::class);
+
+        expect($source)->toContain('companyUserQuery')
+            ->and($source)->toContain('companyChatChannelQuery')
+            ->and($source)->toContain("ChatChannel::where('company_uuid', session('company'))")
+            ->and($source)->toContain("->whereHas('participants'")
+            ->and($source)->not->toContain("User::where('uuid', \$userId)->orWhere('public_id', \$userId)->first()")
+            ->and($source)->not->toContain("ChatChannel::where('uuid', \$channelId)->first()");
     });
 
     test('webhook endpoint request validates webhook urls on create and update', function () {

--- a/tests/Unit/SecurityFindingsTest.php
+++ b/tests/Unit/SecurityFindingsTest.php
@@ -24,6 +24,13 @@ namespace Illuminate\Foundation\Http {
     }
 }
 
+namespace Fleetbase\Tests\SecurityFixtures {
+    class TemplateQueryTenantModel extends \Fleetbase\Models\Model
+    {
+        protected $table = 'template_query_tenant_models';
+    }
+}
+
 namespace {
     use Fleetbase\Http\Controllers\Internal\v1\ApiCredentialController;
     use Fleetbase\Http\Controllers\Internal\v1\ChatChannelController;
@@ -39,7 +46,13 @@ namespace {
     use Fleetbase\Http\Controllers\Internal\v1\UserController;
     use Fleetbase\Http\Requests\Internal\UserForgotPasswordRequest;
     use Fleetbase\Http\Requests\Internal\WebhookEndpointRequest;
+    use Fleetbase\Models\Company;
+    use Fleetbase\Models\TemplateQuery;
     use Fleetbase\Rules\PublicWebhookUrl;
+    use Fleetbase\Services\TemplateRenderService;
+    use Fleetbase\Tests\SecurityFixtures\TemplateQueryTenantModel;
+    use Illuminate\Config\Repository;
+    use Illuminate\Container\Container;
 
     function controller_source(string $class): string
     {
@@ -47,6 +60,18 @@ namespace {
 
         return file_get_contents($reflection->getFileName());
     }
+
+    function bind_security_findings_config(array $values = []): void
+    {
+        Container::getInstance()->instance('config', new Repository($values));
+    }
+
+    beforeEach(function () {
+        bind_security_findings_config([
+            'fleetbase.template_query_models'        => [],
+            'fleetbase.template_global_query_models' => [],
+        ]);
+    });
 
     test('forgot password request does not expose a registered email oracle', function () {
         $rules = (new UserForgotPasswordRequest())->rules();
@@ -153,6 +178,50 @@ namespace {
             ->and($templateSource)->not->toContain('$subjectType::where(\'uuid\', $subjectId)')
             ->and($reportSource)->toContain('reportQuery')
             ->and($reportSource)->toContain("->where('company_uuid', session('company'))");
+    });
+
+    test('template query model allowlist excludes company by default', function () {
+        TemplateRenderService::registerContextType('security_fixture_tenant_model', [
+            'label'       => 'Security Fixture',
+            'description' => 'Security fixture for template query allowlist tests.',
+            'model'       => TemplateQueryTenantModel::class,
+            'variables'   => [],
+        ]);
+
+        expect(TemplateRenderService::isTemplateQueryModelAllowed(TemplateQueryTenantModel::class))->toBeTrue()
+            ->and(TemplateRenderService::isTemplateQueryModelAllowed(Company::class))->toBeFalse();
+    });
+
+    test('template query execution rejects the reported company model vector', function () {
+        $query = new TemplateQuery();
+        $query->fill([
+            'company_uuid'    => 'company-current',
+            'variable_name'   => 'orgs',
+            'model_type'      => Company::class,
+            'conditions'      => [],
+            'limit'           => 500,
+        ]);
+
+        expect($query->execute())->toBeEmpty();
+    });
+
+    test('template query execution enforces allowlist and schema backed tenant scoping', function () {
+        $source = file_get_contents((new ReflectionClass(TemplateQuery::class))->getFileName());
+
+        expect($source)->toContain('TemplateRenderService::isTemplateQueryModelAllowed($modelClass)')
+            ->and($source)->toContain('modelHasCompanyColumn')
+            ->and($source)->toContain("\$companyUuid = \$this->company_uuid ?: session('company')")
+            ->and($source)->toContain("\$model->qualifyColumn('company_uuid')")
+            ->and($source)->toContain('TemplateRenderService::isTemplateQueryModelGloballyQueryable($modelClass)')
+            ->and($source)->not->toContain('getFillable()');
+    });
+
+    test('unsaved template preview binds transient queries to the active company', function () {
+        $templateSource = controller_source(TemplateController::class);
+
+        expect($templateSource)->toContain("'company_uuid'   => session('company')")
+            ->and($templateSource)->toContain("'model_type'")
+            ->and($templateSource)->toContain("data_get(\$q, 'model_type')");
     });
 
     test('chat custom actions bind users and channels to active company membership', function () {

--- a/tests/Unit/SecurityFindingsTest.php
+++ b/tests/Unit/SecurityFindingsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Foundation\Auth\Access {
+    trait AuthorizesRequests
+    {
+    }
+}
+
+namespace Illuminate\Foundation\Bus {
+    trait DispatchesJobs
+    {
+    }
+}
+
+namespace Illuminate\Foundation\Validation {
+    trait ValidatesRequests
+    {
+    }
+}
+
+namespace Illuminate\Foundation\Http {
+    class FormRequest extends \Illuminate\Http\Request
+    {
+    }
+}
+
+namespace {
+    use Fleetbase\Http\Controllers\Internal\v1\CompanyController;
+    use Fleetbase\Http\Requests\Internal\UserForgotPasswordRequest;
+    use Fleetbase\Http\Requests\Internal\WebhookEndpointRequest;
+    use Fleetbase\Rules\PublicWebhookUrl;
+
+    test('forgot password request does not expose a registered email oracle', function () {
+        $rules = (new UserForgotPasswordRequest())->rules();
+
+        expect($rules['email'])->toBe(['required', 'email'])
+            ->and($rules['email'])->not->toContain('exists:users,email');
+    });
+
+    test('company controller owns generic company rest operations', function () {
+        $reflection = new ReflectionClass(CompanyController::class);
+
+        expect($reflection->getMethod('findRecord')->getDeclaringClass()->getName())->toBe(CompanyController::class)
+            ->and($reflection->getMethod('updateRecord')->getDeclaringClass()->getName())->toBe(CompanyController::class)
+            ->and($reflection->getMethod('deleteRecord')->getDeclaringClass()->getName())->toBe(CompanyController::class);
+    });
+
+    test('webhook endpoint request validates webhook urls on create and update', function () {
+        $createRequest = WebhookEndpointRequest::create('/int/v1/webhook-endpoints', 'POST');
+        $updateRequest = WebhookEndpointRequest::create('/int/v1/webhook-endpoints/webhook_123', 'PUT');
+
+        expect($createRequest->rules()['url'][0])->toBe('required')
+            ->and($updateRequest->rules()['url'][0])->toBe('sometimes');
+    });
+
+    test('public webhook url rule accepts public http and https urls', function () {
+        $rule = new PublicWebhookUrl();
+
+        expect($rule->passes('url', 'https://93.184.216.34/hooks/fleetbase'))->toBeTrue()
+            ->and($rule->passes('url', 'http://93.184.216.34/hooks/fleetbase'))->toBeTrue();
+    });
+
+    test('public webhook url rule rejects private and metadata urls', function (string $url) {
+        $rule = new PublicWebhookUrl();
+
+        expect($rule->passes('url', $url))->toBeFalse();
+    })->with([
+        'aws metadata' => ['http://169.254.169.254/latest/meta-data/'],
+        'localhost'    => ['http://localhost/hook'],
+        'loopback v4'  => ['http://127.0.0.1/hook'],
+        'loopback v6'  => ['http://[::1]/hook'],
+        'private 10'   => ['https://10.0.0.1/hook'],
+        'private 172'  => ['https://172.16.0.1/hook'],
+        'private 192'  => ['https://192.168.0.1/hook'],
+        'link local'   => ['https://169.254.10.20/hook'],
+    ]);
+}

--- a/tests/Unit/SecurityFindingsTest.php
+++ b/tests/Unit/SecurityFindingsTest.php
@@ -1,29 +1,5 @@
 <?php
 
-namespace Illuminate\Foundation\Auth\Access {
-    trait AuthorizesRequests
-    {
-    }
-}
-
-namespace Illuminate\Foundation\Bus {
-    trait DispatchesJobs
-    {
-    }
-}
-
-namespace Illuminate\Foundation\Validation {
-    trait ValidatesRequests
-    {
-    }
-}
-
-namespace Illuminate\Foundation\Http {
-    class FormRequest extends \Illuminate\Http\Request
-    {
-    }
-}
-
 namespace Fleetbase\Tests\SecurityFixtures {
     class TemplateQueryTenantModel extends \Fleetbase\Models\Model
     {


### PR DESCRIPTION
## Summary
- harden company user roster lookup against cross-tenant access
- minimize public organization listing and auth organization serialization
- block generic login identity mutation while adding verified admin/self-service email change flows
- tighten reset, email verification, and email-change verification code handling

## Validation
- php -l on touched PHP files
- php-cs-fixer dry-run on touched PHP files
- git diff --check

Full backend test suite was not run because the existing Pest harness is currently blocked by the pre-existing Tests\TestCase issue.