### PR TITLE
Add coverage baseline tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,12 @@ jobs:
 
     - name: Run Tests
       run: composer test:unit
+
+    - name: Generate Coverage Baseline
+      run: composer coverage:baseline
+
+    - name: Upload Coverage Baseline
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-baseline
+        path: coverage/clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea/codeStyleSettings.xml
 composer.lock
 /vendor/
+/coverage/
+/.phpunit.cache/
 .phpunit.result.cache
 .php_cs.cache
 .php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,14 @@
         }
     },
     "scripts": {
+        "coverage:baseline": [
+            "@test:coverage:clover",
+            "@coverage:summary"
+        ],
+        "coverage:summary": "php scripts/coverage-summary.php coverage/clover.xml",
         "lint": "php-cs-fixer fix -v",
+        "test:coverage": "php scripts/coverage-runner.php --coverage --coverage-text --colors=always",
+        "test:coverage:clover": "mkdir -p coverage && php scripts/coverage-runner.php --coverage-clover=coverage/clover.xml --colors=always",
         "test:lint": "php-cs-fixer fix -v --dry-run",
         "test:types": "phpstan analyse --ansi --memory-limit=-1",
         "test:unit": "pest --colors=always",

--- a/scripts/coverage-runner.php
+++ b/scripts/coverage-runner.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+$args = array_slice($argv, 1);
+
+if ($args === []) {
+    fwrite(STDERR, "Usage: php scripts/coverage-runner.php <pest coverage arguments>\n");
+    exit(1);
+}
+
+$pest = getcwd() . '/vendor/bin/pest';
+if (!is_file($pest)) {
+    fwrite(STDERR, "Unable to find Pest at vendor/bin/pest. Run composer install first.\n");
+    exit(1);
+}
+
+$hasCoverageExtension = extension_loaded('xdebug') || extension_loaded('pcov');
+
+if ($hasCoverageExtension) {
+    putenv('XDEBUG_MODE=coverage');
+    $_ENV['XDEBUG_MODE']    = 'coverage';
+    $_SERVER['XDEBUG_MODE'] = 'coverage';
+
+    $command = array_merge([PHP_BINARY, $pest], $args);
+} else {
+    fwrite(STDERR, "No PHP coverage driver is available.\n\n");
+    fwrite(STDERR, "Install or enable one of:\n");
+    fwrite(STDERR, "  - Xdebug with XDEBUG_MODE=coverage\n");
+    fwrite(STDERR, "  - PCOV\n");
+    fwrite(STDERR, "\n");
+    fwrite(STDERR, 'Current PHP binary: ' . PHP_BINARY . "\n");
+    exit(1);
+}
+
+$escapedCommand = implode(' ', array_map('escapeshellarg', $command));
+passthru($escapedCommand, $exitCode);
+
+exit($exitCode);

--- a/scripts/coverage-summary.php
+++ b/scripts/coverage-summary.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+$cloverPath = $argv[1] ?? 'coverage/clover.xml';
+
+if (!is_file($cloverPath)) {
+    fwrite(STDERR, "Coverage file not found: {$cloverPath}\n");
+    fwrite(STDERR, "Run `composer test:coverage:clover` first.\n");
+    exit(1);
+}
+
+$xml = simplexml_load_file($cloverPath);
+if (!$xml) {
+    fwrite(STDERR, "Unable to parse Clover coverage file: {$cloverPath}\n");
+    exit(1);
+}
+
+function coveragePercent(int $covered, int $total): float
+{
+    return $total === 0 ? 0.0 : round(($covered / $total) * 100, 2);
+}
+
+function intMetric(SimpleXMLElement $node, string $name): int
+{
+    return (int) ($node->metrics[$name] ?? 0);
+}
+
+$project = $xml->project;
+$metrics = $project->metrics;
+
+$statements        = (int) ($metrics['statements'] ?? 0);
+$coveredStatements = (int) ($metrics['coveredstatements'] ?? 0);
+$methods           = (int) ($metrics['methods'] ?? 0);
+$coveredMethods    = (int) ($metrics['coveredmethods'] ?? 0);
+$classes           = (int) ($metrics['classes'] ?? 0);
+$coveredClasses    = (int) ($metrics['coveredclasses'] ?? 0);
+
+$files       = [];
+$directories = [];
+
+foreach ($project->xpath('.//file') ?: [] as $file) {
+    $path              = (string) $file['name'];
+    $fileStatements    = intMetric($file, 'statements');
+    $coveredFileLines  = intMetric($file, 'coveredstatements');
+    $fileMethods       = intMetric($file, 'methods');
+    $coveredFileMethod = intMetric($file, 'coveredmethods');
+
+    if ($fileStatements === 0) {
+        continue;
+    }
+
+    $files[] = [
+        'path'            => $path,
+        'covered'         => $coveredFileLines,
+        'statements'      => $fileStatements,
+        'methods'         => $fileMethods,
+        'covered_methods' => $coveredFileMethod,
+        'percent'         => coveragePercent($coveredFileLines, $fileStatements),
+    ];
+
+    $relativePath = preg_replace('#^' . preg_quote(getcwd(), '#') . '/?#', '', $path);
+    $parts        = explode('/', $relativePath ?: $path);
+    $directory    = count($parts) > 2 ? $parts[0] . '/' . $parts[1] : dirname($relativePath ?: $path);
+
+    if (!isset($directories[$directory])) {
+        $directories[$directory] = [
+            'covered'    => 0,
+            'statements' => 0,
+        ];
+    }
+
+    $directories[$directory]['covered'] += $coveredFileLines;
+    $directories[$directory]['statements'] += $fileStatements;
+}
+
+usort($files, function (array $a, array $b): int {
+    return $a['percent'] <=> $b['percent']
+        ?: $b['statements'] <=> $a['statements'];
+});
+
+$directoryRows = [];
+foreach ($directories as $directory => $directoryMetrics) {
+    $directoryRows[] = [
+        'directory'  => $directory,
+        'covered'    => $directoryMetrics['covered'],
+        'statements' => $directoryMetrics['statements'],
+        'percent'    => coveragePercent($directoryMetrics['covered'], $directoryMetrics['statements']),
+    ];
+}
+
+usort($directoryRows, function (array $a, array $b): int {
+    return $a['percent'] <=> $b['percent']
+        ?: $b['statements'] <=> $a['statements'];
+});
+
+printf("Line coverage: %.2f%% (%d/%d statements)\n", coveragePercent($coveredStatements, $statements), $coveredStatements, $statements);
+printf("Method coverage: %.2f%% (%d/%d methods)\n", coveragePercent($coveredMethods, $methods), $coveredMethods, $methods);
+printf("Class coverage: %.2f%% (%d/%d classes)\n", coveragePercent($coveredClasses, $classes), $coveredClasses, $classes);
+
+echo "\nLowest covered directories:\n";
+foreach (array_slice($directoryRows, 0, 10) as $row) {
+    printf("  %6.2f%%  %5d/%-5d  %s\n", $row['percent'], $row['covered'], $row['statements'], $row['directory']);
+}
+
+echo "\nLowest covered files:\n";
+foreach (array_slice($files, 0, 20) as $file) {
+    $relativePath = preg_replace('#^' . preg_quote(getcwd(), '#') . '/?#', '', $file['path']);
+    printf("  %6.2f%%  %5d/%-5d  %s\n", $file['percent'], $file['covered'], $file['statements'], $relativePath ?: $file['path']);
+}


### PR DESCRIPTION
## Summary
- add Composer scripts to generate Pest coverage output and Clover XML
- add a repo-local coverage runner that fails early when PHP has no Xdebug/PCOV coverage driver
- add a repo-local Clover parser that prints line, method, and class coverage plus lowest-covered directories/files
- add CI coverage baseline generation using the existing Xdebug setup and upload the Clover report as an artifact
- ignore generated coverage and PHPUnit cache directories

## Why
This PR establishes a measurable starting coverage percentage before adding more tests. Pest cannot produce coverage without a PHP coverage driver, so the runner now reports that prerequisite directly instead of running tests and failing later because `coverage/clover.xml` was never created.

## Commands
- `composer test:coverage`
- `composer test:coverage:clover`
- `composer coverage:summary`
- `composer coverage:baseline`

## Local and Docker requirement
Coverage requires one enabled PHP coverage driver:
- Xdebug with `XDEBUG_MODE=coverage`
- PCOV

If neither driver is loaded, `composer coverage:baseline` exits before running the suite and prints the PHP binary that needs the extension enabled.

## Validation
- `./vendor/bin/pest --colors=never`
- `php -l scripts/coverage-runner.php`
- `php -l scripts/coverage-summary.php`
- `php scripts/coverage-summary.php /tmp/core-api-clover-sample.xml`
- `./vendor/bin/php-cs-fixer fix -v --dry-run --config=.php-cs-fixer.php .github/workflows/ci.yml .gitignore composer.json scripts/coverage-runner.php scripts/coverage-summary.php`
- `/usr/local/bin/composer coverage:baseline` now fails early with `No PHP coverage driver is available` on local PHP because neither `xdebug` nor `pcov` is loaded.