### PR TITLE
fix(purge): stream backup uploads, verify them, and clean up temp dumps

### DIFF
--- a/src/Console/Commands/PurgeActivityLogs.php
+++ b/src/Console/Commands/PurgeActivityLogs.php
@@ -15,7 +15,8 @@ class PurgeActivityLogs extends Command
                             {--days=30}
                             {--disk=}
                             {--force}
-                            {--skip-backup}';
+                            {--skip-backup}
+                            {--keep-backups=}';
 
     protected $description = 'Purge activity/audit logs.';
 

--- a/src/Console/Commands/PurgeApiLogs.php
+++ b/src/Console/Commands/PurgeApiLogs.php
@@ -16,7 +16,8 @@ class PurgeApiLogs extends Command
                             {--days=30}
                             {--disk=}
                             {--force}
-                            {--skip-backup}';
+                            {--skip-backup}
+                            {--keep-backups=}';
 
     protected $description = 'Purge API request logs and API events.';
 

--- a/src/Console/Commands/PurgeScheduledTaskLogs.php
+++ b/src/Console/Commands/PurgeScheduledTaskLogs.php
@@ -15,7 +15,8 @@ class PurgeScheduledTaskLogs extends Command
                             {--days=30}
                             {--disk=}
                             {--force}
-                            {--skip-backup}';
+                            {--skip-backup}
+                            {--keep-backups=}';
 
     protected $description = 'Purge scheduled task logs.';
 

--- a/src/Console/Commands/PurgeWebhookLogs.php
+++ b/src/Console/Commands/PurgeWebhookLogs.php
@@ -15,7 +15,8 @@ class PurgeWebhookLogs extends Command
                             {--days=30 : Only purge records older than this many days}
                             {--disk= : Filesystem disk for backups; defaults to app default}
                             {--force : Do not ask for interactive confirmation}
-                            {--skip-backup : Skip creating a backup and delete immediately}';
+                            {--skip-backup : Skip creating a backup and delete immediately}
+                            {--keep-backups= : Keep only the N most recent backups for this table; unset disables pruning}';
 
     protected $description = 'Purge webhook request logs.';
 

--- a/src/Exceptions/PurgeBackupException.php
+++ b/src/Exceptions/PurgeBackupException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Fleetbase\Exceptions;
+
+/**
+ * Thrown when a purge backup cannot be verified, aborting before any rows are deleted.
+ */
+class PurgeBackupException extends \RuntimeException
+{
+    protected ?string $disk;
+    protected ?string $remotePath;
+
+    public function __construct(string $reason, ?string $disk = null, ?string $remotePath = null)
+    {
+        $this->disk       = $disk;
+        $this->remotePath = $remotePath;
+
+        $target = $disk && $remotePath ? " [{$disk}:{$remotePath}]" : '';
+
+        parent::__construct("Backup{$target} {$reason}; aborting purge without deleting rows.");
+    }
+
+    public function getDisk(): ?string
+    {
+        return $this->disk;
+    }
+
+    public function getRemotePath(): ?string
+    {
+        return $this->remotePath;
+    }
+}

--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -166,10 +166,10 @@ class CoreServiceProvider extends ServiceProvider
         $this->scheduleCommands(function ($schedule) {
             $schedule->command('cache:prune-stale-tags')->hourly();
             $schedule->command('model:prune', ['--model' => MonitoredScheduledTaskLogItem::class])->twiceDaily(1, 13);
-            $schedule->command('purge:api-logs --force --no-interaction --days 2')->twiceDaily(1, 13);
-            $schedule->command('purge:webhook-logs --force --no-interaction --days 2')->twiceDaily(1, 13);
-            $schedule->command('purge:activity-logs --force --no-interaction --days 2')->twiceDaily(1, 13);
-            $schedule->command('purge:scheduled-task-logs --force --no-interaction --days 1')->twiceDaily(1, 13);
+            $schedule->command('purge:api-logs --force --no-interaction --days 2 --keep-backups=30')->twiceDaily(1, 13);
+            $schedule->command('purge:webhook-logs --force --no-interaction --days 2 --keep-backups=30')->twiceDaily(1, 13);
+            $schedule->command('purge:activity-logs --force --no-interaction --days 2 --keep-backups=30')->twiceDaily(1, 13);
+            $schedule->command('purge:scheduled-task-logs --force --no-interaction --days 1 --keep-backups=30')->twiceDaily(1, 13);
             $schedule->command('telemetry:ping')->daily();
             $schedule->job(new \Fleetbase\Jobs\MaterializeSchedulesJob())->dailyAt('01:00')->name('materialize-schedules')->withoutOverlapping();
             // Keep sandbox users/companies in sync with production so that

--- a/src/Traits/PurgeCommand.php
+++ b/src/Traits/PurgeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Fleetbase\Traits;
 
+use Fleetbase\Exceptions\PurgeBackupException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -40,12 +41,25 @@ trait PurgeCommand
     }
 
     /**
+     * Make sure the directory holding a dump file exists.
+     */
+    protected function ensureDumpDirectory(string $fileName): void
+    {
+        $directory = dirname($fileName);
+
+        if (!is_dir($directory)) {
+            @mkdir($directory, 0775, true);
+        }
+    }
+
+    /**
      * Write a simple SQL INSERT dump to $fileName for the given rows.
      */
     protected function writeSqlDump(string $tableName, Collection $records, string $fileName): void
     {
         if ($records->isEmpty()) {
-            file_put_contents($fileName, "-- empty set\n");
+            $this->ensureDumpDirectory($fileName);
+            file_put_contents($fileName, "-- empty set\n", FILE_APPEND);
 
             return;
         }
@@ -55,7 +69,7 @@ trait PurgeCommand
 
         // Start file (create/overwrite once)
         if (!file_exists($fileName)) {
-            @mkdir(dirname($fileName), 0775, true);
+            $this->ensureDumpDirectory($fileName);
             file_put_contents($fileName, "-- Dump of {$tableName}\n");
         }
 
@@ -79,6 +93,83 @@ trait PurgeCommand
 
         $dump .= implode(",\n", $rows) . ";\n";
         file_put_contents($fileName, $dump, FILE_APPEND);
+    }
+
+    /**
+     * Stream the local dump to the backup disk and prove it landed intact.
+     *
+     * Deleting rows is only safe once the backup is known to exist and to be non-empty,
+     * so every failure here aborts before the caller reaches its delete stage.
+     *
+     * @throws PurgeBackupException when the backup cannot be verified
+     */
+    protected function uploadBackup(string $localTmp, string $disk, string $remote): void
+    {
+        if (!is_file($localTmp) || filesize($localTmp) === 0) {
+            throw new PurgeBackupException('was not written locally, or is empty', $disk, $remote);
+        }
+
+        $filesystem = Storage::disk($disk);
+        $stream     = fopen($localTmp, 'rb');
+        $uploaded   = $stream !== false && $filesystem->writeStream($remote, $stream) !== false;
+
+        if (is_resource($stream)) {
+            fclose($stream);
+        }
+
+        if (!$uploaded || !$filesystem->exists($remote)) {
+            throw new PurgeBackupException('upload failed', $disk, $remote);
+        }
+
+        if ($filesystem->size($remote) === 0) {
+            throw new PurgeBackupException('is empty', $disk, $remote);
+        }
+    }
+
+    /**
+     * Keep only the --keep-backups most recent dumps for this table, if the option is set.
+     *
+     * Scoped to this table's own dumps so a shared or reused backup prefix is never touched,
+     * and non-fatal: the backup is already safe by the time this runs.
+     */
+    protected function pruneBackups(string $disk, string $backupPath, string $tableName, string $justUploaded): void
+    {
+        try {
+            // Commands using this trait without declaring the option simply opt out of pruning.
+            $keep = method_exists($this, 'option') ? $this->option('keep-backups') : null;
+        } catch (\Throwable $e) {
+            return;
+        }
+
+        if ($keep === null || $keep === '' || (int) $keep < 1) {
+            return;
+        }
+
+        $keep       = (int) $keep;
+        $filesystem = Storage::disk($disk);
+
+        try {
+            // Dump names are "<table>_<Y-m-d>_<H-i-s>.sql", so for a single table
+            // sorting by name descending is the same as sorting newest first.
+            $dumps = collect($filesystem->files(trim($backupPath, '/')))
+                ->filter(fn ($path) => $path !== $justUploaded && preg_match('/^' . preg_quote($tableName, '/') . '_[\d\-_]+\.sql$/', basename($path)))
+                ->sortDesc()
+                ->values();
+
+            // The upload we just made is the newest and is excluded above, so it counts against the budget.
+            $stale = $dumps->slice($keep - 1);
+            if ($stale->isEmpty()) {
+                return;
+            }
+
+            foreach ($stale as $path) {
+                $filesystem->delete($path);
+            }
+
+            $this->info("Pruned {$stale->count()} old backup(s), keeping the {$keep} most recent.");
+        } catch (\Throwable $e) {
+            $this->warn('Could not prune old backups: ' . $e->getMessage());
+        }
     }
 
     /**
@@ -144,29 +235,30 @@ trait PurgeCommand
             $disk     = $this->resolveBackupDisk($diskOption);
             $tmpName  = str_replace([' ', ':'], '_', "{$tableName}_" . now()->format('Y-m-d_H-i-s') . '.sql');
             $localTmp = storage_path("app/tmp/{$tmpName}");
-            $this->info("Backing up {$count} records from {$tableName} to '{$disk}:{$backupPath}/{$tmpName}'...");
+            $remote   = trim($backupPath, '/') . "/{$tmpName}";
+            $this->info("Backing up {$count} records from {$tableName} to '{$disk}:{$remote}'...");
 
-            $buffer = collect();
-
-            // stream rows to file in chunks
-            (clone $baseQuery)->orderBy($this->detectPrimaryKey($tableName, $model) ?? 'created_at')->chunk(1000, function ($chunk) use (&$buffer, $tableName, $localTmp) {
-                $buffer = $buffer->concat($chunk->map(fn ($m) => $m->getAttributes()));
-                // Large purge streaming flushes intermediate buffers before the final write.
-                // @codeCoverageIgnoreStart
-                if ($buffer->count() >= 5000) {
-                    $this->writeSqlDump($tableName, $buffer, $localTmp);
-                    $buffer = collect();
-                }
-                // @codeCoverageIgnoreEnd
-            });
-            if ($buffer->count() > 0) {
-                $this->writeSqlDump($tableName, $buffer, $localTmp);
+            // A dump left behind by an earlier run would be appended to rather than replaced.
+            if (is_file($localTmp)) {
+                @unlink($localTmp);
             }
 
-            // upload and done
-            $remote = trim($backupPath, '/') . "/{$tmpName}";
-            Storage::disk($disk)->put($remote, file_get_contents($localTmp));
-            $this->info('Backup uploaded.');
+            try {
+                // Stream rows to file one chunk at a time so neither the rows nor the SQL
+                // they produce are ever fully resident in memory.
+                (clone $baseQuery)->orderBy($this->detectPrimaryKey($tableName, $model) ?? 'created_at')->chunk(1000, function ($chunk) use ($tableName, $localTmp) {
+                    $this->writeSqlDump($tableName, $chunk->map(fn ($m) => $m->getAttributes()), $localTmp);
+                });
+
+                $this->uploadBackup($localTmp, $disk, $remote);
+                $this->pruneBackups($disk, $backupPath, $tableName, $remote);
+            } finally {
+                if (is_file($localTmp)) {
+                    @unlink($localTmp);
+                }
+            }
+
+            $this->info('Backup verified and uploaded.');
         } else {
             $this->warn('Skipping backup as --skip-backup was provided.');
         }

--- a/tests/Unit/Console/PurgeLogCommandsTest.php
+++ b/tests/Unit/Console/PurgeLogCommandsTest.php
@@ -4,6 +4,7 @@ use Fleetbase\Console\Commands\PurgeActivityLogs;
 use Fleetbase\Console\Commands\PurgeApiLogs;
 use Fleetbase\Console\Commands\PurgeScheduledTaskLogs;
 use Fleetbase\Console\Commands\PurgeWebhookLogs;
+use Fleetbase\Exceptions\PurgeBackupException;
 use Fleetbase\Traits\ForcesCommands;
 use Fleetbase\Traits\PurgeCommand;
 use Illuminate\Console\Command;
@@ -242,6 +243,16 @@ class PurgeCommandTestCommand extends Command
     {
         return $this->confirmDeleteLine($tableName);
     }
+
+    public function uploadBackupForTest(string $localTmp, string $disk, string $remote): void
+    {
+        $this->uploadBackup($localTmp, $disk, $remote);
+    }
+
+    public function pruneBackupsForTest(string $disk, string $backupPath, string $tableName, string $justUploaded): void
+    {
+        $this->pruneBackups($disk, $backupPath, $tableName, $justUploaded);
+    }
 }
 
 function purge_log_commands_database(bool $withCreatedAt = true): Capsule
@@ -310,8 +321,55 @@ function purge_log_cutoff(array $purge): ?string
     return $binding instanceof Carbon ? $binding->toDateTimeString() : null;
 }
 
+/**
+ * Swap the 'local' disk for a decorator that delegates to the real one, except for
+ * the methods overridden here. Lets a test make an upload fail the way S3 can:
+ * by returning a value rather than by throwing.
+ */
+function purge_command_break_disk(array $overrides): void
+{
+    $real = Storage::disk('local');
+
+    Storage::set('local', new class($real, $overrides) {
+        public function __construct(private $real, private array $overrides)
+        {
+        }
+
+        public function __call($method, $arguments)
+        {
+            if (isset($this->overrides[$method])) {
+                return ($this->overrides[$method])($this->real, ...$arguments);
+            }
+
+            return $this->real->{$method}(...$arguments);
+        }
+    });
+}
+
+/**
+ * Local dump files left in storage/app/tmp for the given table.
+ *
+ * @return array<int,string>
+ */
+function purge_command_temp_dumps(string $tableName = 'purge_command_records'): array
+{
+    return glob(storage_path("app/tmp/{$tableName}_*.sql")) ?: [];
+}
+
+function purge_command_clear_temp_dumps(string $tableName = 'purge_command_records'): void
+{
+    foreach (purge_command_temp_dumps($tableName) as $path) {
+        @unlink($path);
+    }
+}
+
+beforeEach(function () {
+    purge_command_clear_temp_dumps();
+});
+
 afterEach(function () {
     Carbon::setTestNow();
+    purge_command_clear_temp_dumps();
     Storage::clearResolvedInstances();
     Facade::clearResolvedInstances();
 });
@@ -438,7 +496,7 @@ it('runs purge flow with backup upload deletion and empty set handling', functio
     expect($command->runPurgeForTest(PurgeCommandRecord::query()->where('created_at', '<', '2026-06-15 00:00:00'), new PurgeCommandRecord(), null, 'purge-backups'))->toBe(1)
         ->and(PurgeCommandRecord::query()->pluck('name')->all())->toBe(['Keep'])
         ->and($command->confirmations)->toBe(['Do you want to permanently delete the selected records from purge_command_records?'])
-        ->and($command->infos)->toContain('Backup uploaded.')
+        ->and($command->infos)->toContain('Backup verified and uploaded.')
         ->and($command->infos)->toContain('Purge completed. Deleted: 1');
 
     $diskFiles = Storage::disk('local')->allFiles('purge-backups');
@@ -505,6 +563,204 @@ it('runs purge flow skip backup and decline paths and detects primary keys', fun
         ->and($skipBackup->detectPrimaryKeyForTest('purge_command_records'))->toBe('uuid')
         ->and($skipBackup->detectPrimaryKeyForTest('purge_command_records', new PurgeCommandRecord()))->toBe('id')
         ->and($skipBackup->detectPrimaryKeyForTest('purge_command_no_key_records', new PurgeCommandNoKeyRecord()))->toBeNull();
+});
+
+it('removes the local dump after a successful purge', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $capsule->getConnection('mysql')->table('purge_command_records')->insert([
+        ['id' => 1, 'uuid' => 'record-1', 'name' => 'Delete', 'created_at' => '2026-06-01 00:00:00'],
+    ]);
+
+    $command = new PurgeCommandTestCommand(['force' => true]);
+
+    expect($command->runPurgeForTest(PurgeCommandRecord::query()->where('name', 'Delete'), new PurgeCommandRecord(), null, 'purge-backups'))->toBe(1)
+        ->and(purge_command_temp_dumps())->toBe([])
+        ->and(Storage::disk('local')->allFiles('purge-backups'))->toHaveCount(1);
+});
+
+it('streams large purges to the dump one chunk at a time', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $rows = [];
+    for ($i = 1; $i <= 2500; $i++) {
+        $rows[] = ['id' => $i, 'uuid' => "record-{$i}", 'name' => "Row {$i}", 'created_at' => '2026-06-01 00:00:00'];
+    }
+    foreach (array_chunk($rows, 500) as $batch) {
+        $capsule->getConnection('mysql')->table('purge_command_records')->insert($batch);
+    }
+
+    $command = new PurgeCommandTestCommand(['force' => true]);
+
+    expect($command->runPurgeForTest(PurgeCommandRecord::query()->where('created_at', '<', '2026-06-15 00:00:00'), new PurgeCommandRecord(), null, 'purge-backups'))->toBe(2500)
+        ->and(PurgeCommandRecord::query()->count())->toBe(0)
+        ->and(purge_command_temp_dumps())->toBe([]);
+
+    $dump = Storage::disk('local')->get(Storage::disk('local')->allFiles('purge-backups')[0]);
+
+    // One header, and one INSERT per 1000-row chunk rather than a single buffered write.
+    expect(substr_count($dump, '-- Dump of purge_command_records'))->toBe(1)
+        ->and(substr_count($dump, 'INSERT INTO `purge_command_records`'))->toBe(3)
+        ->and($dump)->toContain("'Row 2500'");
+});
+
+it('aborts without deleting when the backup upload fails', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $capsule->getConnection('mysql')->table('purge_command_records')->insert([
+        ['id' => 1, 'uuid' => 'record-1', 'name' => 'Delete', 'created_at' => '2026-06-01 00:00:00'],
+    ]);
+
+    purge_command_break_disk(['writeStream' => fn () => false]);
+
+    $command = new PurgeCommandTestCommand(['force' => true]);
+
+    expect(fn () => $command->runPurgeForTest(PurgeCommandRecord::query()->where('name', 'Delete'), new PurgeCommandRecord(), null, 'purge-backups'))
+        ->toThrow(PurgeBackupException::class, 'aborting purge without deleting rows')
+        ->and(PurgeCommandRecord::query()->count())->toBe(1)
+        ->and(purge_command_temp_dumps())->toBe([])
+        ->and($command->infos)->not->toContain('Backup verified and uploaded.');
+});
+
+it('aborts without deleting when the uploaded backup is missing', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $capsule->getConnection('mysql')->table('purge_command_records')->insert([
+        ['id' => 1, 'uuid' => 'record-1', 'name' => 'Delete', 'created_at' => '2026-06-01 00:00:00'],
+    ]);
+
+    purge_command_break_disk(['exists' => fn () => false]);
+
+    $command = new PurgeCommandTestCommand(['force' => true]);
+
+    expect(fn () => $command->runPurgeForTest(PurgeCommandRecord::query()->where('name', 'Delete'), new PurgeCommandRecord(), null, 'purge-backups'))
+        ->toThrow(PurgeBackupException::class, 'upload failed')
+        ->and(PurgeCommandRecord::query()->count())->toBe(1)
+        ->and(purge_command_temp_dumps())->toBe([]);
+});
+
+it('aborts without deleting when the uploaded backup is empty', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $capsule->getConnection('mysql')->table('purge_command_records')->insert([
+        ['id' => 1, 'uuid' => 'record-1', 'name' => 'Delete', 'created_at' => '2026-06-01 00:00:00'],
+    ]);
+
+    purge_command_break_disk(['size' => fn () => 0]);
+
+    $command = new PurgeCommandTestCommand(['force' => true]);
+
+    expect(fn () => $command->runPurgeForTest(PurgeCommandRecord::query()->where('name', 'Delete'), new PurgeCommandRecord(), null, 'purge-backups'))
+        ->toThrow(PurgeBackupException::class, 'is empty')
+        ->and(PurgeCommandRecord::query()->count())->toBe(1)
+        ->and(purge_command_temp_dumps())->toBe([]);
+});
+
+it('aborts when the local dump was never written or is empty', function () {
+    purge_log_commands_database();
+
+    $command = new PurgeCommandTestCommand();
+    $missing = storage_path('app/tmp/purge_command_records_never-written.sql');
+    $empty   = storage_path('app/tmp/purge_command_records_empty.sql');
+
+    if (!is_dir(dirname($empty))) {
+        mkdir(dirname($empty), 0775, true);
+    }
+    file_put_contents($empty, '');
+
+    expect(fn () => $command->uploadBackupForTest($missing, 'local', 'purge-backups/missing.sql'))
+        ->toThrow(PurgeBackupException::class, 'was not written locally, or is empty')
+        ->and(fn () => $command->uploadBackupForTest($empty, 'local', 'purge-backups/empty.sql'))
+        ->toThrow(PurgeBackupException::class, 'was not written locally, or is empty');
+
+    @unlink($empty);
+});
+
+it('does not append to a dump left behind by an earlier run', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $capsule->getConnection('mysql')->table('purge_command_records')->insert([
+        ['id' => 1, 'uuid' => 'record-1', 'name' => 'Delete', 'created_at' => '2026-06-01 00:00:00'],
+    ]);
+
+    // Same table, same second: exactly what an aborted run leaves behind.
+    $stale = storage_path('app/tmp/purge_command_records_2026-07-17_12-00-00.sql');
+    if (!is_dir(dirname($stale))) {
+        mkdir(dirname($stale), 0775, true);
+    }
+    file_put_contents($stale, "-- Dump of purge_command_records\nINSERT INTO `purge_command_records` (`id`) VALUES (999);\n");
+
+    $command = new PurgeCommandTestCommand(['force' => true]);
+
+    expect($command->runPurgeForTest(PurgeCommandRecord::query()->where('name', 'Delete'), new PurgeCommandRecord(), null, 'purge-backups'))->toBe(1);
+
+    $dump = Storage::disk('local')->get(Storage::disk('local')->allFiles('purge-backups')[0]);
+
+    expect(substr_count($dump, '-- Dump of purge_command_records'))->toBe(1)
+        ->and($dump)->not->toContain('(999)')
+        ->and(purge_command_temp_dumps())->toBe([]);
+});
+
+it('prunes old backups down to keep-backups leaving unrelated objects alone', function () {
+    $capsule = purge_log_commands_database();
+    Carbon::setTestNow(Carbon::parse('2026-07-17 12:00:00'));
+
+    $capsule->getConnection('mysql')->table('purge_command_records')->insert([
+        ['id' => 1, 'uuid' => 'record-1', 'name' => 'Delete', 'created_at' => '2026-06-01 00:00:00'],
+    ]);
+
+    Storage::disk('local')->put('purge-backups/purge_command_records_2026-01-01_00-00-00.sql', 'old');
+    Storage::disk('local')->put('purge-backups/purge_command_records_2026-02-01_00-00-00.sql', 'older');
+    Storage::disk('local')->put('purge-backups/purge_command_records_2026-03-01_00-00-00.sql', 'newest kept');
+    Storage::disk('local')->put('purge-backups/other_table_2026-01-01_00-00-00.sql', 'not ours');
+    Storage::disk('local')->put('purge-backups/notes.txt', 'not a dump');
+
+    $command = new PurgeCommandTestCommand(['force' => true, 'keep-backups' => 2]);
+
+    expect($command->runPurgeForTest(PurgeCommandRecord::query()->where('name', 'Delete'), new PurgeCommandRecord(), null, 'purge-backups'))->toBe(1)
+        ->and(Storage::disk('local')->allFiles('purge-backups'))->toBe([
+            'purge-backups/notes.txt',
+            'purge-backups/other_table_2026-01-01_00-00-00.sql',
+            'purge-backups/purge_command_records_2026-03-01_00-00-00.sql',
+            'purge-backups/purge_command_records_2026-07-17_12-00-00.sql',
+        ])
+        ->and($command->infos)->toContain('Pruned 2 old backup(s), keeping the 2 most recent.');
+});
+
+it('leaves old backups alone when keep-backups is unset or invalid', function () {
+    purge_log_commands_database();
+
+    Storage::disk('local')->put('purge-backups/purge_command_records_2026-01-01_00-00-00.sql', 'old');
+    Storage::disk('local')->put('purge-backups/purge_command_records_2026-02-01_00-00-00.sql', 'older');
+
+    $unset    = new PurgeCommandTestCommand();
+    $blank    = new PurgeCommandTestCommand(['keep-backups' => '']);
+    $zero     = new PurgeCommandTestCommand(['keep-backups' => 0]);
+    $uploaded = 'purge-backups/purge_command_records_2026-07-17_12-00-00.sql';
+
+    $unset->pruneBackupsForTest('local', 'purge-backups', 'purge_command_records', $uploaded);
+    $blank->pruneBackupsForTest('local', 'purge-backups', 'purge_command_records', $uploaded);
+    $zero->pruneBackupsForTest('local', 'purge-backups', 'purge_command_records', $uploaded);
+
+    expect(Storage::disk('local')->allFiles('purge-backups'))->toHaveCount(2)
+        ->and($unset->infos)->toBe([]);
+});
+
+it('warns instead of failing when pruning old backups errors', function () {
+    purge_log_commands_database();
+
+    purge_command_break_disk(['files' => fn () => throw new RuntimeException('listing denied')]);
+
+    $command = new PurgeCommandTestCommand(['keep-backups' => 2]);
+    $command->pruneBackupsForTest('local', 'purge-backups', 'purge_command_records', 'purge-backups/whatever.sql');
+
+    expect($command->warnings)->toBe(['Could not prune old backups: listing denied']);
 });
 
 it('runs purge flow through model deletes when no primary key can be detected', function () {

--- a/tests/Unit/Providers/CoreProviderContractsTest.php
+++ b/tests/Unit/Providers/CoreProviderContractsTest.php
@@ -939,10 +939,10 @@ namespace {
                 ->and(array_map(fn ($event) => $event->name, $provider->schedule->commands))->toBe([
                     'cache:prune-stale-tags',
                     'model:prune',
-                    'purge:api-logs --force --no-interaction --days 2',
-                    'purge:webhook-logs --force --no-interaction --days 2',
-                    'purge:activity-logs --force --no-interaction --days 2',
-                    'purge:scheduled-task-logs --force --no-interaction --days 1',
+                    'purge:api-logs --force --no-interaction --days 2 --keep-backups=30',
+                    'purge:webhook-logs --force --no-interaction --days 2 --keep-backups=30',
+                    'purge:activity-logs --force --no-interaction --days 2 --keep-backups=30',
+                    'purge:scheduled-task-logs --force --no-interaction --days 1 --keep-backups=30',
                     'telemetry:ping',
                     'sandbox:sync',
                 ])


### PR DESCRIPTION
## Summary

Fixes the `purge:*` commands, which never completed on tables of any size. Reported in #233.

`runPurge()` streamed rows to a local temp file in bounded chunks — then handed that file to `Storage::put()` via `file_get_contents()`, making the entire dump resident in PHP memory and undoing the streaming one line later. On a multi-GB dump this exhausted `memory_limit` and killed the process **before** the DELETE stage: no backup written, no rows purged, and the temp file orphaned on disk. All four commands are scheduled `twiceDaily(1, 13)`, so this failed twice a day on any deployment of size.

## What changed

**`src/Traits/PurgeCommand.php`**

1. **Stream the upload.** `writeStream()` instead of `put(file_get_contents(...))` — memory stays flat regardless of dump size.
2. **Verify the backup before deleting.** `Storage::put()` returns `bool` and the return value was discarded, so `Backup uploaded.` printed unconditionally and DELETE proceeded regardless. A new `PurgeBackupException` now aborts unless the write succeeded *and* the remote object exists *and* is non-empty. `--skip-backup` remains the explicit way to consent to deleting without a backup — an unverified backup should not be treated as the same thing.
3. **Always clean up the temp dump.** There was no `unlink()` anywhere in the file, on any path. Now removed in a `finally`, so success, abort, and any future unrelated failure all clean up.
4. **Removed a second, independent memory peak.** The flush threshold buffered **5000 rows** of `getAttributes()` and then built the whole 5000-row INSERT as one string. Each 1000-row chunk now goes straight to disk. This matters most on `api_request_logs`, which stores full request and response bodies — fixing only the upload would have left a smaller version of the same bug.
5. **Stale dumps are no longer appended to.** `writeSqlDump()` only writes its `-- Dump of …` header `if (!file_exists($fileName))`. Combined with the leak above, a leftover file from an aborted run with the same name was silently appended to rather than replaced.

**`--keep-backups=N`** — new option on all four commands, pruning older dumps for that table after a verified upload. Scoped by filename to the table's own dumps so a shared or reused backup prefix is never touched, and non-fatal (the backup is already safe by then). Default is unset/off so no existing manual invocation suddenly starts deleting; the four scheduled invocations pass `--keep-backups=30`, so the out-of-the-box schedule is bounded.

## Tests

10 new cases in `tests/Unit/Console/PurgeLogCommandsTest.php`, all against a real local disk:

- temp dump removed after a successful purge, and after a failed one
- no rows deleted when `writeStream()` returns `false`, when the object is missing after write, or when it is 0 bytes
- local dump missing or empty aborts before upload
- a 2500-row purge produces one header and three INSERTs — verifying per-chunk streaming rather than a single buffered write
- a stale same-name dump is discarded, not appended to
- prune keeps the N newest, leaves non-matching objects alone, and does nothing when the option is unset, blank, or zero
- prune failure warns rather than aborting

`./vendor/bin/pest` and `php-cs-fixer` are green. One pre-existing unrelated failure in `ApiCredentialControllerTest` is present on the base branch too and is untouched here.

## Notes

- Aborting throws, so `purge:api-logs` will not continue to `api_events` if the `api_request_logs` backup fails. That is deliberate — the point is to fail loudly rather than proceed on an unverified backup.
- `src/Support/SqlDumper.php` has the same `file_get_contents()` shape in `getCompanyDumpSql()`, but has no production callers in this package, so it is out of scope here.

Credit to @MarioLisbona for an unusually thorough report — three environments of field evidence, and two self-corrections narrowing the claim to what the data actually supported.

Refs #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
