### PR TITLE
fix(exceptions): stop rendering HTML stack traces to API clients

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -87,6 +87,46 @@ class Handler extends ExceptionHandler
     }
 
     /**
+     * Determine if the exception should be rendered as JSON.
+     *
+     * Fleetbase is a JSON-only HTTP surface, but clients do not reliably send an
+     * `Accept: application/json` header. Laravel's default would then render an HTML
+     * error page for any exception not covered by shouldManuallyHandleException(),
+     * leaking file paths and stack frames to API consumers. Outside of local debugging
+     * always answer with JSON; when debugging is on the HTML page is kept, since it is
+     * the more useful development affordance.
+     *
+     * @param \Illuminate\Http\Request $request
+     */
+    protected function shouldReturnJson($request, \Throwable $e): bool
+    {
+        if (!config('app.debug')) {
+            return true;
+        }
+
+        return parent::shouldReturnJson($request, $e);
+    }
+
+    /**
+     * Convert the given exception to an array.
+     *
+     * Matches the `{"errors": [...]}` envelope used by response()->error() so error
+     * payloads are consistent across the API, and withholds internals when debugging
+     * is off. HTTP exception messages are preserved because they describe the request
+     * the caller already made; anything else collapses to a generic message.
+     */
+    protected function convertExceptionToArray(\Throwable $e): array
+    {
+        if (config('app.debug')) {
+            return parent::convertExceptionToArray($e);
+        }
+
+        $message = $this->isHttpException($e) && $e->getMessage() !== '' ? $e->getMessage() : 'Server Error';
+
+        return ['errors' => [$message]];
+    }
+
+    /**
      * Retrieves a loggable message from an exception for CloudWatch.
      *
      * This function attempts to extract a loggable message from the given exception object.
@@ -162,16 +202,16 @@ class Handler extends ExceptionHandler
 
         switch ($type) {
             case 'TokenMismatchException':
-                return response()->error('Invalid XSRF token sent with request.');
+                return response()->error('Invalid XSRF token sent with request.', 419);
 
             case 'ThrottleRequestsException':
-                return response()->error('Too many requests.');
+                return response()->error('Too many requests.', 429);
 
             case 'AuthenticationException':
-                return response()->error('Unauthenticated.');
+                return response()->error('Unauthenticated.', 401);
 
             case 'NotFoundHttpException':
-                return response()->error('There is nothing to see here.');
+                return response()->error('There is nothing to see here.', 404);
 
             case 'ModelNotFoundException':
                 return response()->error($this->modelNotFoundMessage($exception), 404);

--- a/tests/Unit/Exceptions/ExceptionHandlerTest.php
+++ b/tests/Unit/Exceptions/ExceptionHandlerTest.php
@@ -20,6 +20,29 @@ namespace Illuminate\Foundation\Exceptions {
             protected function reportable(callable $callback): void
             {
             }
+
+            // Mirrors Illuminate\Foundation\Exceptions\Handler so the overrides under
+            // test can delegate to a parent, as they do against the real framework.
+            protected function shouldReturnJson($request, \Throwable $e)
+            {
+                return $request->expectsJson();
+            }
+
+            protected function convertExceptionToArray(\Throwable $e)
+            {
+                return [
+                    'message'   => $e->getMessage(),
+                    'exception' => get_class($e),
+                    'file'      => $e->getFile(),
+                    'line'      => $e->getLine(),
+                    'trace'     => [],
+                ];
+            }
+
+            protected function isHttpException(\Throwable $e)
+            {
+                return $e instanceof \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+            }
         }
     }
 }
@@ -43,6 +66,7 @@ namespace {
     use Illuminate\Http\Request;
     use Illuminate\Session\TokenMismatchException;
     use Illuminate\Support\Facades\Facade;
+    use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
     use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
     class TestableExceptionHandler extends Handler
@@ -83,10 +107,10 @@ namespace {
                 'errors' => $expectedErrors,
             ]);
     })->with([
-        'token mismatch'         => [new TokenMismatchException(), ['Invalid XSRF token sent with request.'], 400],
-        'throttled request'      => [new ThrottleRequestsException('Slow down'), ['Too many requests.'], 400],
-        'authentication failure' => [new AuthenticationException(), ['Unauthenticated.'], 400],
-        'http not found'         => [new NotFoundHttpException(), ['There is nothing to see here.'], 400],
+        'token mismatch'         => [new TokenMismatchException(), ['Invalid XSRF token sent with request.'], 419],
+        'throttled request'      => [new ThrottleRequestsException('Slow down'), ['Too many requests.'], 429],
+        'authentication failure' => [new AuthenticationException(), ['Unauthenticated.'], 401],
+        'http not found'         => [new NotFoundHttpException(), ['There is nothing to see here.'], 404],
     ]);
 
     it('returns a resource-specific model not found json response when the model is known', function () {
@@ -203,6 +227,86 @@ namespace {
         $exception = new RuntimeException("\xB1\x31");
 
         expect($handler->getCloudwatchLoggableException($exception))->toBe("\xB1\x31");
+    });
+
+    it('forces json error responses when debugging is off so API clients never receive html', function () {
+        bind_test_container(['app.debug' => false]);
+        Facade::clearResolvedInstances();
+        $handler = new Handler(app());
+        $method  = new ReflectionMethod($handler, 'shouldReturnJson');
+        $method->setAccessible(true);
+
+        // A browser-shaped request: no Accept: application/json, no XHR header. Laravel
+        // would render the HTML error page for this; the override must not.
+        $request = Request::create('/v1/orders', 'GET');
+
+        expect($method->invoke($handler, $request, new RuntimeException('boom')))->toBeTrue();
+    });
+
+    it('defers to the framework content negotiation while debugging is on', function () {
+        bind_test_container(['app.debug' => true]);
+        Facade::clearResolvedInstances();
+        $handler = new Handler(app());
+        $method  = new ReflectionMethod($handler, 'shouldReturnJson');
+        $method->setAccessible(true);
+
+        $htmlRequest = Request::create('/v1/orders', 'GET');
+        $jsonRequest = Request::create('/v1/orders', 'GET', server: ['HTTP_ACCEPT' => 'application/json']);
+
+        expect($method->invoke($handler, $htmlRequest, new RuntimeException('boom')))->toBeFalse()
+            ->and($method->invoke($handler, $jsonRequest, new RuntimeException('boom')))->toBeTrue();
+    });
+
+    it('withholds paths and stack frames from error payloads when debugging is off', function () {
+        bind_test_container(['app.debug' => false]);
+        Facade::clearResolvedInstances();
+        $handler = new Handler(app());
+        $method  = new ReflectionMethod($handler, 'convertExceptionToArray');
+        $method->setAccessible(true);
+
+        $payload = $method->invoke($handler, new RuntimeException('Connection refused at /srv/app/secret.php'));
+
+        expect($payload)->toBe(['errors' => ['Server Error']])
+            ->and($payload)->not->toHaveKeys(['file', 'line', 'trace', 'exception']);
+    });
+
+    it('preserves http exception messages in the error envelope when debugging is off', function () {
+        bind_test_container(['app.debug' => false]);
+        Facade::clearResolvedInstances();
+        $handler = new Handler(app());
+        $method  = new ReflectionMethod($handler, 'convertExceptionToArray');
+        $method->setAccessible(true);
+
+        // A bare HttpExceptionInterface rather than a Symfony subclass: their constructors
+        // emit implicit-nullable deprecations on newer PHP, and only the interface matters here.
+        $exception = new class('The PUT method is not supported for route v1/orders.') extends RuntimeException implements HttpExceptionInterface {
+            public function getStatusCode(): int
+            {
+                return 405;
+            }
+
+            public function getHeaders(): array
+            {
+                return [];
+            }
+        };
+
+        $payload = $method->invoke($handler, $exception);
+
+        expect($payload)->toBe(['errors' => ['The PUT method is not supported for route v1/orders.']]);
+    });
+
+    it('keeps the full framework payload while debugging is on', function () {
+        bind_test_container(['app.debug' => true]);
+        Facade::clearResolvedInstances();
+        $handler = new Handler(app());
+        $method  = new ReflectionMethod($handler, 'convertExceptionToArray');
+        $method->setAccessible(true);
+
+        $payload = $method->invoke($handler, new RuntimeException('Unexpected failure'));
+
+        expect($payload)->toHaveKeys(['message', 'exception', 'file', 'line', 'trace'])
+            ->and($payload['message'])->toBe('Unexpected failure');
     });
 
     it('keeps a default manual error response for explicitly invoked fallback handling', function () {


### PR DESCRIPTION
## Problem

`Handler::render()` never inspected the request. It routed on the exception's **short class name** against a hardcoded six-item allowlist and handed everything else to `parent::render()` → `shouldReturnJson()` → `$request->expectsJson()`.

Nothing on `/v1/*` forces JSON — the `fleetbase.api` middleware group has no `ForceJsonResponse` equivalent. So **any API client that omitted `Accept: application/json` got Laravel's HTML error page for every unlisted exception**, leaking absolute paths, class names and stack frames.

Confirmed live on unrelated endpoints — this was never specific to one route:

```
PUT  /v1/orders                            -> 405 text/html 1,105,667 bytes
POST /v1/onboard/driver-onboard-settings/x -> 405 text/html 1,105,923 bytes
```

`MethodNotAllowedHttpException` is thrown **during routing, before route middleware runs** — which is why a middleware-based fix would not have covered it. `QueryException`, `TypeError`, `AccessDeniedHttpException`, `ValidationException` and most of Fleetbase's own exceptions fall through identically.

Adding `Accept: application/json` returned JSON but, with `APP_DEBUG=true`, that JSON still carried the full frame list.

## Changes

**1. `shouldReturnJson()`** — returns `true` whenever `APP_DEBUG` is off, so a deployed API never answers HTML regardless of where the exception was thrown. With debugging on it defers to the framework, keeping the HTML debug page as a local development affordance (deliberate: the debug page is genuinely useful locally).

**2. `convertExceptionToArray()`** — emits the `{"errors": [...]}` envelope used by `response()->error()` everywhere else, and withholds `file`/`line`/`exception`/`trace` when debugging is off. HTTP exception messages are preserved (they only describe the request the caller already made); anything else collapses to `Server Error`.

**3. Status codes** — the allowlist relied on `response()->error()`'s 400 default:

| Exception | Before | After |
|---|---|---|
| `NotFoundHttpException` | 400 | **404** |
| `ThrottleRequestsException` | 400 | **429** |
| `AuthenticationException` | 400 | **401** |
| `TokenMismatchException` | 400 | **419** |
| `ModelNotFoundException` | 404 | 404 (unchanged) |
| `FleetbaseRequestValidationException` | 400 | 400 (unchanged, deliberate) |

Validation stays at 400: 422 is the conventional answer and probably right long-term, but it has the widest blast radius on the Ember console, so it belongs in its own change.

Verified live before the fix: `GET /v1/definitely-not-a-route` returned `400 {"errors":["There is nothing to see here."]}`.

## Trade-off worth reviewing

Leak protection now rests on `APP_DEBUG=false` in deployed environments. That is already the Laravel default (`env('APP_DEBUG', false)`), but it is a single point of failure — flagging it explicitly rather than burying it.

Side note: `unauthenticated()` returns 401 but is dead code — `render()` intercepts `AuthenticationException` first. With this change the two finally agree. Left in place.

## Tests

`tests/Unit/Exceptions/ExceptionHandlerTest.php` — **19 passed (56 assertions)**, run on PHP 8.4. Updated the pinned statuses and added coverage for both overrides: force-JSON when debug is off, delegation when on, redacted envelope, preserved HTTP messages, and full framework payload while debugging.

The test file's framework stub gained `shouldReturnJson`/`convertExceptionToArray`/`isHttpException` mirroring Illuminate, so the overrides delegate to a parent exactly as they do in production.

## Related

Surfaced by a 500 on `GET /v1/onboard/driver-onboard-settings/{companyId}`, fixed separately in fleetbase/fleetops#290. That was the trigger; this is the reachable-everywhere defect.

## Verification status

Unit tests pass. :warning: The live `APP_DEBUG=false` behavior is **not verified** — the dev stack was down. To confirm once one is up: set `APP_DEBUG=false`, `php artisan config:clear`, then `curl -s -X PUT -H "Authorization: Bearer <key>" -w '\n%{http_code} %{content_type} %{size_download}\n' http://localhost:8000/v1/orders` should return a few hundred bytes of `{"errors":[…]}`, not 1.1 MB of `text/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
