### PR TITLE
ci(release): tag automatically when a dev-v* branch merges to main

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,7 +14,8 @@ jobs:
           with:
             tag_name: ${{ github.ref_name }}
             name: ${{ github.ref_name }}
-            generate_release_notes: true 
+            body_path: RELEASE.md
+            generate_release_notes: true
             draft: false
             prerelease: false
           env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release Tag
+
+# Tags a release when a `dev-v*` branch is merged to main, and pushes the tag. Delegates
+# to the reusable workflow in fleetbase/fleetbase. Requires org secret _GITHUB_AUTH_TOKEN
+# (inherited); no-ops with a warning until it is set.
+#
+# It pushes the tag and nothing else — create-release.yml and the publish jobs in this
+# repository already chain off `push: tags: v*`.
+#
+# The version is never retyped: it comes from the branch name, and the tag is refused
+# unless the files below and RELEASE.md already agree with it. This repository is
+# server-only, so composer.json is the single source of the version.
+#
+# RELEASE.md is required, and its first line must name the version being released. That
+# check is the only thing that can tell notes written for this release from the previous
+# release's notes nobody replaced.
+#
+# Deliberately unpinned, like postman.yml — it tracks the reusable workflow on main, so
+# there is no ref here to remember to bump.
+#
+# workflow_dispatch is the recovery path. Use it when a release failed validation and the
+# fix landed on main after the merge: re-running the merge event would check out the
+# merge commit and never see that fix.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag, e.g. 1.2.3. Recovery only — a normal release reads it from the branch."
+        required: true
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: github.event_name == 'workflow_dispatch' ||
+        (github.event.pull_request.merged == true &&
+         startsWith(github.event.pull_request.head.ref, 'dev-v'))
+    uses: fleetbase/fleetbase/.github/workflows/release-tag.yml@main
+    with:
+      version-files: composer.json
+      version: ${{ github.event.inputs.version || '' }}
+    secrets: inherit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+> v1.6.55 ~ "RELEASE_NOTES_PLACEHOLDER — replace this line with the release title"
+
+---
+## Highlights
+
+RELEASE_NOTES_PLACEHOLDER
+
+Describe what changed in this release. The first line above must name the version
+being released, and both placeholder markers must be gone, or the release workflow
+refuses to tag.
+
+---
+## Need help?
+- [GitHub Discussions](https://github.com/fleetbase/fleetbase/discussions)
+- [Discord](https://discord.gg/HnTqQ6zAVn)


### PR DESCRIPTION
Adds the release-tag caller. Part of the rollout for fleetbase/fleetbase#620, which holds the reusable workflow this delegates to.

## What it does

When a `dev-v*` branch is merged to main, it validates and pushes the tag — **and nothing else**. `create-release.yml` and the publish jobs in this repository already chain off `push: tags: ['v*']`, so a second release path would duplicate them.

The version is never retyped. It comes from the branch name (`dev-v1.2.3` ⇒ `v1.2.3`), and the tag is refused unless every version file and `RELEASE.md` already agree with it.

## Validation, each failing rather than warning

- the PR was merged, not merely closed, from a `dev-v<semver>` branch
- every version file exists, yields a version, and matches
- `RELEASE.md` exists, is non-empty, and **its first line names this version**
- no tag already exists at a different commit (same commit is a safe no-op)

The tag goes on the PR's merge commit, never on `main` at run time.

## Before this can release

1. **fleetbase/fleetbase#620 must merge first** — `@main` will not resolve until it does.
2. **This repo needs a `RELEASE.md`** whose first line names the version, e.g.
   ```
   > v1.2.3 ~ "What this release is about"
   ```
   Without it the notes check fails and no tag is pushed. That check is the only thing that can distinguish notes written for this release from the previous release's notes nobody replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
