### PR TITLE
v1.6.58: defer database resolution during package discovery

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,23 +1,18 @@
-> v1.6.57 ~ "Settings changes take effect without clearing the cache by hand"
+> v1.6.58 ~ "Release images install without requiring a live database"
 
 ---
 ## Highlights
-Writing a system setting did not invalidate the cache entry the reader actually uses, so the old value kept being served until the cache was cleared manually. On a default install — `api/.env.example` ships `CACHE_DRIVER=file` — nothing invalidated it at all.
-
-This surfaced as a rotated platform API token being rejected as invalid: the new hash was written to the database, and every request kept validating against the previously cached one.
+Core API no longer opens a MySQL connection while Composer discovers Laravel packages. Fresh Fleetbase images can install their dependencies before the database service exists.
 
 ---
 ## Bug Fixes
-- **A saved setting invalidated the wrong cache key.** `Setting::system('platform_api.token_hash')` caches under `system_settings.platform_api.token_hash`, using the key exactly as the caller passed it, while the row is stored as `system.platform_api.token_hash`. The model's `saved`/`deleted` events built the cache key from the row, producing `system_settings.system.platform_api.token_hash` — a key nothing ever writes. Both spellings are now forgotten.
-- **Saving a setting threw when Redis was not configured.** `Utils::clearCacheByPattern()` resolved a Redis connection unguarded, and the `saved` event calls through it — so on an install without Redis, an ordinary `Setting::configureSystem()` write raised a binding exception. Pattern clearing is inherently Redis-only; without Redis there is nothing to enumerate, so it now skips instead of failing.
-
----
-## Known limitations
-`Utils::clearCacheByPattern()` still only clears entries on Redis. That no longer matters for settings, which now invalidate their own keys directly, but a caller relying on pattern clearing for something else will not see it work on another driver.
+- Resolved the database-backed user-deletion service only when `fleetbase:user-delete` is actually executed.
+- Prevented Laravel's console command discovery from constructing a spatial MySQL connection during `composer install` and `composer dumpautoload`.
+- Added regression coverage proving the command can be registered and resolved while its database service is unavailable.
 
 ---
 ## Upgrade Steps
-No migration and no configuration change. If a platform API token was rotated and rejected on an earlier version, rotate it once more after upgrading — or clear the cache — so the stale hash is dropped.
+No migration or configuration change is required.
 
 ---
 ## Need help?

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.57",
+    "version": "1.6.58",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/src/Console/Commands/DeleteUser.php
+++ b/src/Console/Commands/DeleteUser.php
@@ -19,13 +19,21 @@ class DeleteUser extends Command
 
     protected $description = 'Safely preview and delete users and their identity-bound resources across Fleetbase schemas';
 
-    public function __construct(protected UserDeletionService $deletionService)
+    protected UserDeletionService $deletionService;
+
+    public function __construct()
     {
         parent::__construct();
     }
 
-    public function handle(): int
+    public function handle(UserDeletionService $deletionService): int
     {
+        // Resolve the database-backed service only when this command is executed.
+        // Laravel instantiates every registered command during package discovery;
+        // constructor injection here opened MySQL while the release image was still
+        // being built, before a database service existed.
+        $this->deletionService = $deletionService;
+
         $emailOption = $this->option('email');
         $email       = is_string($emailOption) && $emailOption !== '' ? $emailOption : null;
         $uuids       = array_values(array_unique(array_filter((array) $this->option('uuid'), 'is_string')));

--- a/tests/Unit/Console/DeleteUserCommandTest.php
+++ b/tests/Unit/Console/DeleteUserCommandTest.php
@@ -2,6 +2,7 @@
 
 use Fleetbase\Console\Commands\DeleteUser;
 use Fleetbase\Services\UserDeletionService;
+use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 
 class DeleteUserServiceFake extends UserDeletionService
@@ -52,9 +53,9 @@ class DeleteUserCommandFixture extends DeleteUser
 
     public bool $confirmation = true;
 
-    public function __construct(UserDeletionService $service, public array $options = [])
+    public function __construct(public array $options = [])
     {
-        parent::__construct($service);
+        parent::__construct();
     }
 
     public function option($key = null)
@@ -105,17 +106,26 @@ function delete_user_command_fixture(array $options = []): array
         'blockers' => [],
     ];
 
-    return [new DeleteUserCommandFixture($service, $options), $service];
+    return [new DeleteUserCommandFixture($options), $service];
 }
+
+it('resolves without resolving the database-backed deletion service', function () {
+    $container = new Container();
+    $container->bind(UserDeletionService::class, function () {
+        throw new RuntimeException('database service must stay lazy');
+    });
+
+    expect($container->make(DeleteUser::class))->toBeInstanceOf(DeleteUser::class);
+});
 
 it('requires exactly one selector and validates UUIDs', function () {
     [$missing] = delete_user_command_fixture();
     [$both]    = delete_user_command_fixture(['email' => 'shiv@fleetbase.io', 'uuid' => ['11111111-1111-4111-8111-111111111111']]);
     [$invalid] = delete_user_command_fixture(['uuid' => ['not-a-uuid']]);
 
-    expect($missing->handle())->toBe(1)
-        ->and($both->handle())->toBe(1)
-        ->and($invalid->handle())->toBe(1)
+    expect($missing->handle(new DeleteUserServiceFake()))->toBe(1)
+        ->and($both->handle(new DeleteUserServiceFake()))->toBe(1)
+        ->and($invalid->handle(new DeleteUserServiceFake()))->toBe(1)
         ->and($invalid->messages)->toContain(['error', 'Invalid UUIDs: not-a-uuid']);
 });
 
@@ -123,7 +133,7 @@ it('reports no matches without planning a deletion', function () {
     [$command, $service] = delete_user_command_fixture(['email' => 'nobody@fleetbase.io']);
     $service->users      = collect();
 
-    expect($command->handle())->toBe(0)
+    expect($command->handle($service))->toBe(0)
         ->and($command->messages)->toContain(['warn', 'No matching users were found.'])
         ->and($service->calls)->toBe([['find', 'nobody@fleetbase.io', []]]);
 });
@@ -131,7 +141,7 @@ it('reports no matches without planning a deletion', function () {
 it('defaults to a dry run and displays only impacted actions', function () {
     [$command, $service] = delete_user_command_fixture(['uuid' => ['11111111-1111-4111-8111-111111111111', '11111111-1111-4111-8111-111111111111']]);
 
-    expect($command->handle())->toBe(0)
+    expect($command->handle($service))->toBe(0)
         ->and($command->messages)->toContain(['info', 'Dry run only. Re-run with --execute to apply this plan.'])
         ->and($command->tables)->toHaveCount(2)
         ->and($command->tables[1][1])->toHaveCount(1)
@@ -142,7 +152,7 @@ it('fails closed when the plan has unresolved blockers', function () {
     [$command, $service]             = delete_user_command_fixture(['email' => 'shiv@fleetbase.io']);
     $service->planResult['blockers'] = ['external.required_user_uuid'];
 
-    expect($command->handle())->toBe(1)
+    expect($command->handle($service))->toBe(1)
         ->and($command->messages)->toContain(['error', 'Deletion is blocked by unresolved references: external.required_user_uuid']);
 });
 
@@ -150,7 +160,7 @@ it('cancels an executed deletion when confirmation is declined', function () {
     [$command, $service]   = delete_user_command_fixture(['email' => 'shiv@fleetbase.io', 'execute' => true]);
     $command->confirmation = false;
 
-    expect($command->handle())->toBe(0)
+    expect($command->handle($service))->toBe(0)
         ->and($command->messages)->toContain(['warn', 'Deletion cancelled.'])
         ->and(collect($service->calls)->pluck(0)->all())->not->toContain('execute');
 });
@@ -159,10 +169,10 @@ it('executes with confirmation or the explicit yes option', function () {
     [$confirmed, $confirmedService] = delete_user_command_fixture(['email' => 'shiv@fleetbase.io', 'execute' => true]);
     [$forced, $forcedService]       = delete_user_command_fixture(['email' => 'shiv@fleetbase.io', 'execute' => true, 'yes' => true]);
 
-    expect($confirmed->handle())->toBe(0)
+    expect($confirmed->handle($confirmedService))->toBe(0)
         ->and($confirmed->messages)->toContain(['info', 'Deleted 1 users successfully.'])
         ->and(collect($confirmedService->calls)->pluck(0)->all())->toContain('execute')
-        ->and($forced->handle())->toBe(0)
+        ->and($forced->handle($forcedService))->toBe(0)
         ->and(collect($forced->messages)->pluck(0)->all())->not->toContain('confirm')
         ->and(collect($forcedService->calls)->pluck(0)->all())->toContain('execute');
 });
@@ -171,6 +181,6 @@ it('reports execution failures as rolled back', function () {
     [$command, $service]    = delete_user_command_fixture(['email' => 'shiv@fleetbase.io', 'execute' => true, 'yes' => true]);
     $service->executeResult = new RuntimeException('foreign key blocked');
 
-    expect($command->handle())->toBe(1)
+    expect($command->handle($service))->toBe(1)
         ->and($command->messages)->toContain(['error', 'Deletion failed and was rolled back: foreign key blocked']);
 });


### PR DESCRIPTION
## Summary
- resolve `UserDeletionService` only when `fleetbase:user-delete` executes
- prevent Composer/Laravel package discovery from opening MySQL during image builds
- bump Core API to v1.6.58 and add current release notes

## Regression coverage
- verifies the command resolves while the database-backed service binding throws
- preserves dry-run, validation, confirmation, execution, and rollback behavior

## Validation
- `vendor/bin/pest tests/Unit/Console/DeleteUserCommandTest.php` (8 passed, 26 assertions)
- `composer test:unit` (1,416 passed, 9,941 assertions)
- `composer test:lint` (0 files need changes)
- `composer test:date-drift`
- root API `php artisan package:discover --ansi` with `DB_HOST=127.0.0.1 DB_PORT=1`

This fixes the v0.7.54 release image regression where `composer dumpautoload` failed with a MySQL connection-refused error before database services were available.