### PR TITLE
v1.6.59

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,29 @@
-> v1.6.58 ~ "Release images install without requiring a live database"
+> v1.6.59 ~ "Verification and credentials email can render again"
 
 ---
 ## Highlights
-Core API no longer opens a MySQL connection while Composer discovers Laravel packages. Fresh Fleetbase images can install their dependencies before the database service exists.
+Both mail templates failed to compile, so **every verification and credentials email threw instead of sending**. Any flow that delivers a code — customer signup, SMS login with email fallback, password reset, account closure, driver login — returned a 400 carrying a Blade parse error.
+
+Shipped in v1.6.56 and present in v1.6.57 and v1.6.58. Upgrade if you are on any of those.
 
 ---
 ## Bug Fixes
-- Resolved the database-backed user-deletion service only when `fleetbase:user-delete` is actually executed.
-- Prevented Laravel's console command discovery from constructing a spatial MySQL connection during `composer install` and `composer dumpautoload`.
-- Added regression coverage proving the command can be registered and resolved while its database service is unavailable.
+- **`verification.blade.php` and `user-credentials.blade.php` did not parse.** The greeting read `Good Morning@if($user->name), ...@endif`, and Blade only treats `@` as a directive when the preceding character is **not** a word character — the rule that keeps `foo@bar.com` from compiling. So the `@if` was left as literal text while its `@endif` compiled anyway, leaving an unmatched `endif` that broke the enclosing `if/elseif/else`:
+
+  ```
+  syntax error, unexpected token "else", expecting end of file
+  (View: .../core-api/views/mail/verification.blade.php)
+  ```
+
+  The greeting is now built in one expression, so no directive sits against a word.
+
+---
+## Testing
+- Added a test that compiles **every** Blade view in the package and runs `php -l` over the result. Nothing caught the original break because no test ever compiled a view — the templates were only exercised through mocked mailers, which never render them.
 
 ---
 ## Upgrade Steps
-No migration or configuration change is required.
+No migration and no configuration change. If verification emails were failing, they will work again once this is deployed; no codes need reissuing.
 
 ---
 ## Need help?

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/core-api",
-    "version": "1.6.58",
+    "version": "1.6.59",
     "description": "Core Framework and Resources for Fleetbase API",
     "keywords": [
         "fleetbase",

--- a/tests/Unit/Views/MailViewsCompileTest.php
+++ b/tests/Unit/Views/MailViewsCompileTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/**
+ * Every Blade view in the package must compile to parseable PHP.
+ *
+ * verification.blade.php and user-credentials.blade.php both shipped broken: the greeting
+ * read `Good Morning@if($user->name), ...@endif`, and Blade only treats `@` as a directive
+ * when the preceding character is NOT a word character — the rule that stops `foo@bar.com`
+ * compiling. So the `@if` stayed literal text while its `@endif` compiled anyway, leaving
+ * an unmatched endif that broke the enclosing if/elseif/else:
+ *
+ *   syntax error, unexpected token "else", expecting end of file
+ *
+ * The whole view failed to parse, so every verification and credentials mail threw instead
+ * of sending. Nothing caught it because no test ever compiled a view — the templates were
+ * only ever exercised through mocked mailers.
+ */
+it('compiles every blade view to parseable php', function () {
+    $viewPath = dirname(__DIR__, 3) . '/views';
+    $files    = [];
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($viewPath));
+
+    foreach ($iterator as $file) {
+        if ($file->isFile() && str_ends_with($file->getFilename(), '.blade.php')) {
+            $files[] = $file->getPathname();
+        }
+    }
+
+    expect($files)->not->toBeEmpty();
+
+    // withoutComponentTags(): compiling <x-mail-layout> resolves a View Factory out of the
+    // container, which a unit harness has no reason to bind. The bug this guards lives in
+    // the directive layer, which is still compiled in full.
+    $compiler = new BladeCompiler(new Filesystem(), sys_get_temp_dir());
+    $compiler->withoutComponentTags();
+
+    $broken   = [];
+
+    foreach ($files as $file) {
+        $tmp = tempnam(sys_get_temp_dir(), 'blade_') . '.php';
+        file_put_contents($tmp, $compiler->compileString(file_get_contents($file)));
+
+        // php -l is the only honest check here: a template compiles to a string just fine
+        // and can still be a parse error, which is exactly what shipped.
+        $output = [];
+        exec('php -l ' . escapeshellarg($tmp) . ' 2>&1', $output, $status);
+        @unlink($tmp);
+
+        if ($status !== 0) {
+            $broken[] = basename($file) . ': ' . implode(' ', $output);
+        }
+    }
+
+    expect($broken)->toBe([]);
+});

--- a/views/mail/user-credentials.blade.php
+++ b/views/mail/user-credentials.blade.php
@@ -1,12 +1,19 @@
 <x-mail-layout>
 <h2 style="font-size: 18px; font-weight: 600;">
-@if($currentHour < 12)
-    Good Morning@if($user->name), {{ \Fleetbase\Support\Utils::delinkify($user->name) }}@endif!
-@elseif($currentHour < 18)
-    Good Afternoon@if($user->name), {{ \Fleetbase\Support\Utils::delinkify($user->name) }}@endif!
-@else
-    Good Evening@if($user->name), {{ \Fleetbase\Support\Utils::delinkify($user->name) }}@endif!
-@endif
+@php
+    // Blade only treats `@` as a directive when the preceding character is NOT a word
+    // character — the rule that keeps `foo@bar.com` from compiling. `Good Morning@if(...)`
+    // therefore stayed literal text while its `@endif` still compiled, leaving an
+    // unmatched endif that broke the enclosing if/elseif/else. The whole view failed to
+    // parse, so every mail using it threw instead of sending.
+    //
+    // Build the greeting in one expression instead, so no directive ever sits against a
+    // word. delinkify() returns '' for a null or empty name, which is what makes the
+    // no-name case fall through to the bare greeting.
+    $greeting  = $currentHour < 12 ? 'Good Morning' : ($currentHour < 18 ? 'Good Afternoon' : 'Good Evening');
+    $recipient = \Fleetbase\Support\Utils::delinkify($user?->name);
+@endphp
+{{ $recipient === '' ? $greeting : $greeting . ', ' . $recipient }}!
 </h2>
 
 Your login credentials:

--- a/views/mail/verification.blade.php
+++ b/views/mail/verification.blade.php
@@ -1,12 +1,19 @@
 <x-mail-layout>
 <h2 style="font-size: 18px; font-weight: 600;">
-@if($currentHour < 12)
-    Good Morning@if($user->name), {{ \Fleetbase\Support\Utils::delinkify($user->name) }}@endif!
-@elseif($currentHour < 18)
-    Good Afternoon@if($user->name), {{ \Fleetbase\Support\Utils::delinkify($user->name) }}@endif!
-@else
-    Good Evening@if($user->name), {{ \Fleetbase\Support\Utils::delinkify($user->name) }}@endif!
-@endif
+@php
+    // Blade only treats `@` as a directive when the preceding character is NOT a word
+    // character — the rule that keeps `foo@bar.com` from compiling. `Good Morning@if(...)`
+    // therefore stayed literal text while its `@endif` still compiled, leaving an
+    // unmatched endif that broke the enclosing if/elseif/else. The whole view failed to
+    // parse, so every mail using it threw instead of sending.
+    //
+    // Build the greeting in one expression instead, so no directive ever sits against a
+    // word. delinkify() returns '' for a null or empty name, which is what makes the
+    // no-name case fall through to the bare greeting.
+    $greeting  = $currentHour < 12 ? 'Good Morning' : ($currentHour < 18 ? 'Good Afternoon' : 'Good Evening');
+    $recipient = \Fleetbase\Support\Utils::delinkify($user?->name);
+@endphp
+{{ $recipient === '' ? $greeting : $greeting . ', ' . $recipient }}!
 </h2>
 
 @if($content)


### PR DESCRIPTION
Ready for immediate release: version bumped and `RELEASE.md` written, so merging tags `v1.6.59` and publishes.

**Both mail templates failed to compile, so every verification and credentials email threw instead of sending.** Any flow that delivers a code returned a 400 carrying the Blade error — customer signup, SMS login with email fallback, password reset, account closure, driver login.

```
syntax error, unexpected token "else", expecting end of file
(View: .../core-api/views/mail/verification.blade.php)
```

## Cause

The greeting read:

```blade
Good Morning@if($user->name), {{ delinkify($user->name) }}@endif!
```

Blade only treats `@` as a directive when the preceding character is **not** a word character — the rule that keeps `foo@bar.com` from compiling. So `Morning@if(...)` stayed literal text while the `@endif` after the echo compiled normally, leaving an unmatched `endif` that broke the enclosing `if/elseif/else`. Confirmed by compiling the view and reading the output:

```php
<?php if($currentHour < 12): ?>
    Good Morning@if($user->name), <?php echo e(...); ?><?php endif; ?>!
<?php elseif($currentHour < 18): ?>     ← now orphaned
```

Introduced in v1.6.56 by the fix for a null user name, and shipped again in **v1.6.57 and v1.6.58**. `user-credentials.blade.php` has the identical break.

## Fix

The greeting is built in one expression, so no directive ever sits against a word. `delinkify()` returns `''` for a null or empty name, which is what makes the no-name case fall through to the bare greeting.

## Why nothing caught it

**No test ever compiled a view** — the templates were only exercised through mocked mailers, which never render them. This PR adds a test that compiles *every* Blade view in the package and runs `php -l` over the result. I verified it fails against the shipped template and passes against the fix, so it is a real guard.

Full suite green; coverage gate at 100%.

## Impact on the contract runs

This is the cause of most of the current failures in both collections — `Request Customer Creation Code`, `Request Customer Login SMS`, `Request Driver Login SMS`, `Forgot Customer Password`, `Authenticate a Customer via SMS`, `Start Account Closure`, `Setups a verification request`. They should clear once this is in the published image.

Two failures are **not** explained by this and remain open: fleetops `List Organizations` (`Invalid platform API token.`) and storefront `List Network Stores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)