### PR TITLE
fix(webhooks): a queue worker signed lifecycle webhooks with a stale secret

### DIFF
--- a/src/Listeners/SendResourceLifecycleWebhook.php
+++ b/src/Listeners/SendResourceLifecycleWebhook.php
@@ -19,6 +19,21 @@ use Laravel\Sanctum\PersonalAccessToken;
 class SendResourceLifecycleWebhook implements ShouldQueue
 {
     /**
+     * Session keys which carry the request context a lifecycle event was created in.
+     *
+     * @var string[]
+     */
+    protected static array $contextSessionKeys = [
+        'api_credential',
+        'api_key',
+        'api_secret',
+        'api_environment',
+        'is_sandbox',
+        'company',
+        'user',
+    ];
+
+    /**
      * Handle the event.
      *
      * @param ResourceLifecycleEvent $event
@@ -27,15 +42,35 @@ class SendResourceLifecycleWebhook implements ShouldQueue
      */
     public function handle($event)
     {
-        $this->setSessionFromEvent($event);
+        // The context serialized on the event is the only trustworthy source for this job. A long
+        // running queue worker keeps its session between jobs, so the context left behind by a
+        // previously handled event must never be preferred over, or leak into, this one.
+        $context        = static::resolveEventContext($event);
+        $restoreSession = $this->applySessionContext($context);
 
-        // get session variables or fallback to event value
-        $companyId       = session()->get('company', $event->companySession);
-        $apiCredentialId = session()->get('api_credential', $event->apiCredential);
-        $apiKey          = session()->get('api_key', $event->apiKey ?? 'console');
-        $apiSecret       = session()->get('api_secret', $event->apiSecret ?? 'internal');
-        $apiEnvironment  = session()->get('api_environment', $event->apiEnvironment ?? 'live');
-        $isSandbox       = session()->get('is_sandbox', $event->isSandbox);
+        try {
+            $this->sendWebhooksForEvent($event, $context);
+        } finally {
+            $restoreSession();
+        }
+    }
+
+    /**
+     * Send the webhooks for a single lifecycle event using the context serialized on it.
+     *
+     * @param ResourceLifecycleEvent $event
+     * @param array<string, mixed>   $context
+     *
+     * @return void
+     */
+    protected function sendWebhooksForEvent($event, array $context)
+    {
+        $companyId       = $context['company'];
+        $apiCredentialId = $context['api_credential'];
+        $apiKey          = $context['api_key'];
+        $apiSecret       = $context['api_secret'];
+        $apiEnvironment  = $context['api_environment'];
+        $isSandbox       = $context['is_sandbox'];
 
         // Compute the event payload exactly once so the persisted ApiEvent record and the
         // outbound webhook body are guaranteed to be identical. $event->getEventData() resolves
@@ -53,17 +88,14 @@ class SendResourceLifecycleWebhook implements ShouldQueue
             'description'         => $this->getHumanReadableEventDescription($event),
         ];
 
-        // Get api credential from session
-        $apiCredential = session('api_credential');
-
         // Validate api credential, if not uuid then it could be internal
-        if ($apiCredential && Str::isUuid($apiCredential) && ApiCredential::where('uuid', session('api_credential'))->exists()) {
-            $eventData['api_credential_uuid'] = $apiCredential;
+        if ($apiCredentialId && Str::isUuid($apiCredentialId) && ApiCredential::where('uuid', $apiCredentialId)->exists()) {
+            $eventData['api_credential_uuid'] = $apiCredentialId;
         }
 
         // Check if it was a personal access token which made the request
-        if ($apiCredential && is_numeric($apiCredential) && PersonalAccessToken::where('id', $apiCredential)->exists()) {
-            $eventData['access_token_id'] = (int) $apiCredential;
+        if ($apiCredentialId && is_numeric($apiCredentialId) && PersonalAccessToken::where('id', $apiCredentialId)->exists()) {
+            $eventData['access_token_id'] = (int) $apiCredentialId;
         }
 
         try {
@@ -154,36 +186,72 @@ class SendResourceLifecycleWebhook implements ShouldQueue
         }
     }
 
-    public function setSessionFromEvent($event)
+    /**
+     * Resolve the request context which was serialized onto the event when it was dispatched.
+     *
+     * @param ResourceLifecycleEvent $event
+     *
+     * @return array<string, mixed>
+     */
+    public static function resolveEventContext($event): array
     {
-        // set session variables if not set
-        if (!session()->has('api_credential')) {
-            session()->put('api_credential', $event->apiCredential);
+        return [
+            'api_credential'  => $event->apiCredential,
+            'api_key'         => $event->apiKey ?? 'console',
+            'api_secret'      => $event->apiSecret ?? 'internal',
+            'api_environment' => $event->apiEnvironment ?? 'live',
+            'is_sandbox'      => (bool) $event->isSandbox,
+            'company'         => $event->companySession,
+            'user'            => $event->userSession,
+        ];
+    }
+
+    /**
+     * Replace the session context with the context serialized on the event.
+     *
+     * The session is replaced unconditionally: a queue worker session may already hold the context
+     * of an event it handled earlier, and that context must not be applied to this event. Downstream
+     * code (model scopes, observers, resources) still reads this context from the session, so it is
+     * written there for the duration of the job only.
+     *
+     * @param ResourceLifecycleEvent $event
+     *
+     * @return callable a callback which restores the session to the state it was in before the event
+     */
+    public function setSessionFromEvent($event): callable
+    {
+        return $this->applySessionContext(static::resolveEventContext($event));
+    }
+
+    /**
+     * Write a resolved event context to the session, replacing whatever was there before.
+     *
+     * @param array<string, mixed> $context
+     *
+     * @return callable a callback which restores the session to the state it was in before the event
+     */
+    protected function applySessionContext(array $context): callable
+    {
+        $previous = [];
+
+        foreach (static::$contextSessionKeys as $key) {
+            if (session()->has($key)) {
+                $previous[$key] = session()->get($key);
+            }
+
+            session()->put($key, $context[$key]);
         }
 
-        if (!session()->has('api_key')) {
-            session()->put('api_key', $event->apiKey);
-        }
+        return function () use ($previous) {
+            foreach (static::$contextSessionKeys as $key) {
+                if (array_key_exists($key, $previous)) {
+                    session()->put($key, $previous[$key]);
+                    continue;
+                }
 
-        if (!session()->has('api_secret')) {
-            session()->put('api_secret', $event->apiSecret);
-        }
-
-        if (!session()->has('api_environment')) {
-            session()->put('api_environment', $event->apiEnvironment);
-        }
-
-        if (!session()->has('is_sandbox')) {
-            session()->put('is_sandbox', $event->isSandbox);
-        }
-
-        if (!session()->has('company')) {
-            session()->put('company', $event->companySession);
-        }
-
-        if (!session()->has('user')) {
-            session()->put('user', $event->userSession);
-        }
+                session()->remove($key);
+            }
+        };
     }
 
     /**

--- a/tests/Unit/EventsAndExceptionsTest.php
+++ b/tests/Unit/EventsAndExceptionsTest.php
@@ -788,7 +788,11 @@ test('resource lifecycle webhook listener restores event session defaults and de
         'companySession'      => 'company-uuid',
     ]);
 
-    $listener->setSessionFromEvent($event);
+    // stale context left in a long running queue worker session must be replaced, not preserved
+    session()->put('api_credential', 'stale-credential-uuid');
+    session()->put('api_secret', 'stale-secret');
+
+    $restoreSession = $listener->setSessionFromEvent($event);
 
     expect(session('api_credential'))->toBe('credential-uuid')
         ->and(session('api_key'))->toBe('key')
@@ -798,4 +802,11 @@ test('resource lifecycle webhook listener restores event session defaults and de
         ->and(session('company'))->toBe('company-uuid')
         ->and(session('user'))->toBe('user-uuid')
         ->and($listener->getHumanReadableEventDescription($event))->toBe('A order (Order 1001) was assigned a driver via API');
+
+    $restoreSession();
+
+    expect(session('api_credential'))->toBe('stale-credential-uuid')
+        ->and(session('api_secret'))->toBe('stale-secret')
+        ->and(session()->has('company'))->toBeFalse()
+        ->and(session()->has('user'))->toBeFalse();
 });

--- a/tests/Unit/Listeners/ResourceLifecycleWebhookListenerTest.php
+++ b/tests/Unit/Listeners/ResourceLifecycleWebhookListenerTest.php
@@ -202,6 +202,35 @@ namespace {
         }
     }
 
+    class ResourceLifecycleWebhookListenerSessionSpyResource extends JsonResource
+    {
+        public static array $observed = [];
+
+        public static function reset(): void
+        {
+            static::$observed = [];
+        }
+
+        public function toWebhookPayload(): array
+        {
+            static::$observed[] = [
+                'api_credential'  => session('api_credential'),
+                'api_key'         => session('api_key'),
+                'api_secret'      => session('api_secret'),
+                'api_environment' => session('api_environment'),
+                'is_sandbox'      => session('is_sandbox'),
+                'company'         => session('company'),
+                'user'            => session('user'),
+            ];
+
+            return [
+                'id'     => $this->resource->public_id,
+                'uuid'   => $this->resource->uuid,
+                'status' => $this->resource->status,
+            ];
+        }
+    }
+
     class ResourceLifecycleWebhookListenerEvent extends ResourceLifecycleEvent
     {
         public ?EloquentModel $record  = null;
@@ -232,6 +261,47 @@ namespace {
         {
             return $this->resource ?? new JsonResource($model);
         }
+    }
+
+    function resource_lifecycle_webhook_listener_record(array $attributes = []): FleetbaseModel
+    {
+        $record = new FleetbaseModel();
+        $record->setRawAttributes(array_merge([
+            'uuid'         => 'record-uuid',
+            'public_id'    => 'order_1234567',
+            'company_uuid' => 'company-uuid',
+            'status'       => 'dispatched',
+        ], $attributes), true);
+
+        return $record;
+    }
+
+    function resource_lifecycle_webhook_listener_event(array $context, ?EloquentModel $record = null, ?JsonResource $resource = null): ResourceLifecycleWebhookListenerEvent
+    {
+        $record = $record ?? resource_lifecycle_webhook_listener_record();
+
+        return ResourceLifecycleWebhookListenerEvent::fake(array_merge([
+            'modelName'           => 'order',
+            'modelClassNamespace' => FleetbaseModel::class,
+            'modelClassName'      => 'Order',
+            'modelHumanName'      => 'order',
+            'modelUuid'           => 'record-uuid',
+            'namespace'           => '\\Fleetbase',
+            'version'             => 1,
+            'eventName'           => 'updated',
+            'sentAt'              => '2026-07-18 15:25:00',
+            'eventId'             => 'event_lifecycle',
+            'apiVersion'          => 'v1',
+            'requestMethod'       => 'PATCH',
+            'apiCredential'       => null,
+            'apiSecret'           => 'event-secret',
+            'apiKey'              => 'event-api-key',
+            'apiEnvironment'      => 'live',
+            'isSandbox'           => false,
+            'data'                => [],
+            'userSession'         => null,
+            'companySession'      => 'company-uuid',
+        ], $context), $record, $resource ?? new ResourceLifecycleWebhookListenerResource($record));
     }
 
     function resource_lifecycle_webhook_listener_database(): array
@@ -403,6 +473,7 @@ namespace {
     }
 
     afterEach(function () {
+        ResourceLifecycleWebhookListenerSessionSpyResource::reset();
         session()->flush();
         Carbon::setTestNow();
         EloquentModel::clearBootedModels();
@@ -490,99 +561,182 @@ namespace {
             ->and($bus->jobs[0]->meta['api_event_uuid'])->toBe($apiEvent->uuid)
             ->and($bus->jobs[0]->meta['webhook_uuid'])->toBe('webhook-enabled')
             ->and($bus->jobs[0]->headers)->toHaveKey('X-Fleetbase-Signature')
-            ->and(session('company'))->toBe('company-uuid')
-            ->and(session('api_environment'))->toBe('live');
+            ->and(session('company'))->toBeNull()
+            ->and(session('api_environment'))->toBeNull();
     });
 
-    test('resource lifecycle webhook listener preserves session credential attribution', function () {
+    test('resource lifecycle webhook listener prefers event credential attribution over a stale worker session', function () {
         [$capsule, $bus] = resource_lifecycle_webhook_listener_database();
 
+        // context left behind in the worker session by a previously handled event
         session()->put('api_credential', '11111111-1111-4111-8111-111111111111');
         session()->put('api_key', 'session-api-key');
         session()->put('api_secret', 'session-secret');
 
-        $record = new FleetbaseModel();
-        $record->setRawAttributes([
-            'uuid'         => 'record-uuid',
-            'public_id'    => 'order_1234567',
-            'company_uuid' => 'company-uuid',
-            'status'       => 'dispatched',
-        ], true);
-
-        $event = ResourceLifecycleWebhookListenerEvent::fake([
-            'modelName'           => 'order',
-            'modelClassNamespace' => FleetbaseModel::class,
-            'modelClassName'      => 'Order',
-            'modelHumanName'      => 'order',
-            'modelUuid'           => 'record-uuid',
-            'namespace'           => '\\Fleetbase',
-            'version'             => 1,
-            'eventName'           => 'updated',
-            'sentAt'              => '2026-07-18 15:25:00',
-            'eventId'             => 'event_lifecycle',
-            'apiVersion'          => 'v1',
-            'requestMethod'       => 'PATCH',
-            'apiCredential'       => 'internal-console',
-            'apiSecret'           => 'event-secret',
-            'apiKey'              => 'event-api-key',
-            'apiEnvironment'      => 'live',
-            'isSandbox'           => false,
-            'data'                => [],
-            'userSession'         => null,
-            'companySession'      => 'company-uuid',
-        ], $record, new ResourceLifecycleWebhookListenerResource($record));
+        $event = resource_lifecycle_webhook_listener_event([
+            'apiCredential' => '44',
+            'apiSecret'     => 'event-secret',
+            'apiKey'        => 'event-api-key',
+        ]);
 
         (new SendResourceLifecycleWebhook())->handle($event);
 
         $apiEvent = ApiEvent::first();
 
-        expect($apiEvent->api_credential_uuid)->toBe('11111111-1111-4111-8111-111111111111')
-            ->and($apiEvent->access_token_id)->toBeNull()
+        expect($apiEvent->access_token_id)->toBe(44)
+            ->and($apiEvent->api_credential_uuid)->toBeNull()
             ->and($bus->jobs)->toHaveCount(1)
-            ->and($bus->jobs[0]->meta['api_key'])->toBe('session-api-key')
-            ->and($bus->jobs[0]->meta['api_credential_uuid'])->toBe('11111111-1111-4111-8111-111111111111')
-            ->and($bus->jobs[0]->meta['access_token_id'])->toBeNull()
-            ->and($bus->jobs[0]->headers)->toHaveKey('X-Fleetbase-Signature');
+            ->and($bus->jobs[0]->meta['api_key'])->toBe('event-api-key')
+            ->and($bus->jobs[0]->meta['access_token_id'])->toBe(44)
+            ->and($bus->jobs[0]->meta['api_credential_uuid'])->toBeNull()
+            ->and($bus->jobs[0]->headers['X-Fleetbase-Signature'])->toBe(hash_hmac('sha256', json_encode($bus->jobs[0]->payload), 'event-secret'));
+    });
+
+    test('resource lifecycle webhook listener restores the previous session context after handling an event', function () {
+        resource_lifecycle_webhook_listener_database();
+
+        session()->put('api_credential', '11111111-1111-4111-8111-111111111111');
+        session()->put('api_key', 'session-api-key');
+        session()->put('company', 'other-company');
+
+        $record = resource_lifecycle_webhook_listener_record();
+        $event  = resource_lifecycle_webhook_listener_event([
+            'apiCredential'  => '44',
+            'apiKey'         => 'event-api-key',
+            'apiSecret'      => 'event-secret',
+            'companySession' => 'company-uuid',
+            'userSession'    => 'user-uuid',
+        ], $record, new ResourceLifecycleWebhookListenerSessionSpyResource($record));
+
+        (new SendResourceLifecycleWebhook())->handle($event);
+
+        // the event context is visible to downstream code while the job runs
+        expect(ResourceLifecycleWebhookListenerSessionSpyResource::$observed[0])->toBe([
+            'api_credential'  => '44',
+            'api_key'         => 'event-api-key',
+            'api_secret'      => 'event-secret',
+            'api_environment' => 'live',
+            'is_sandbox'      => false,
+            'company'         => 'company-uuid',
+            'user'            => 'user-uuid',
+        ])
+            // and the session it was running in is handed back untouched
+            ->and(session('api_credential'))->toBe('11111111-1111-4111-8111-111111111111')
+            ->and(session('api_key'))->toBe('session-api-key')
+            ->and(session('company'))->toBe('other-company')
+            ->and(session()->has('api_secret'))->toBeFalse()
+            ->and(session()->has('api_environment'))->toBeFalse()
+            ->and(session()->has('is_sandbox'))->toBeFalse()
+            ->and(session()->has('user'))->toBeFalse();
+    });
+
+    test('resource lifecycle webhook listener signs each queued event with its own secret', function () {
+        [$capsule, $bus] = resource_lifecycle_webhook_listener_database();
+
+        $listener = new SendResourceLifecycleWebhook();
+        $record   = resource_lifecycle_webhook_listener_record();
+
+        // two events handled back to back by the same long running worker
+        $listener->handle(resource_lifecycle_webhook_listener_event([
+            'eventId'        => 'event_first',
+            'apiCredential'  => '11111111-1111-4111-8111-111111111111',
+            'apiKey'         => 'flb_live_key',
+            'apiSecret'      => 'secret-a',
+            'userSession'    => 'user-uuid',
+        ], $record, new ResourceLifecycleWebhookListenerSessionSpyResource($record)));
+
+        $listener->handle(resource_lifecycle_webhook_listener_event([
+            'eventId'        => 'event_second',
+            'apiCredential'  => '44',
+            'apiKey'         => 'console',
+            'apiSecret'      => 'secret-b',
+            'userSession'    => null,
+        ], $record, new ResourceLifecycleWebhookListenerSessionSpyResource($record)));
+
+        expect($bus->jobs)->toHaveCount(2);
+
+        [$first, $second] = $bus->jobs;
+
+        expect($first->headers['X-Fleetbase-Signature'])->toBe(hash_hmac('sha256', json_encode($first->payload), 'secret-a'))
+            ->and($first->headers['X-Fleetbase-Signature'])->not->toBe(hash_hmac('sha256', json_encode($first->payload), 'secret-b'))
+            ->and($second->headers['X-Fleetbase-Signature'])->toBe(hash_hmac('sha256', json_encode($second->payload), 'secret-b'))
+            ->and($second->headers['X-Fleetbase-Signature'])->not->toBe(hash_hmac('sha256', json_encode($second->payload), 'secret-a'))
+            ->and($first->meta['api_key'])->toBe('flb_live_key')
+            ->and($second->meta['api_key'])->toBe('console');
+
+        $apiEvents = ApiEvent::all();
+
+        expect($apiEvents)->toHaveCount(2)
+            ->and($apiEvents[0]->api_credential_uuid)->toBe('11111111-1111-4111-8111-111111111111')
+            ->and($apiEvents[0]->access_token_id)->toBeNull()
+            ->and($apiEvents[1]->api_credential_uuid)->toBeNull()
+            ->and($apiEvents[1]->access_token_id)->toBe(44);
+
+        $observed = ResourceLifecycleWebhookListenerSessionSpyResource::$observed;
+
+        expect($observed[0]['api_secret'])->toBe('secret-a')
+            ->and($observed[0]['api_credential'])->toBe('11111111-1111-4111-8111-111111111111')
+            ->and($observed[0]['api_key'])->toBe('flb_live_key')
+            ->and($observed[0]['user'])->toBe('user-uuid')
+            ->and($observed[1]['api_secret'])->toBe('secret-b')
+            ->and($observed[1]['api_credential'])->toBe('44')
+            ->and($observed[1]['api_key'])->toBe('console')
+            ->and($observed[1]['user'])->toBeNull()
+            ->and(session()->has('api_secret'))->toBeFalse();
+    });
+
+    test('resource lifecycle webhook listener does not leak environment sandbox or company context between queued events', function () {
+        [$capsule, $bus] = resource_lifecycle_webhook_listener_database();
+
+        $listener = new SendResourceLifecycleWebhook();
+        $record   = resource_lifecycle_webhook_listener_record();
+
+        // a sandbox event is handled first and must not push the next live event into sandbox
+        $listener->handle(resource_lifecycle_webhook_listener_event([
+            'eventId'        => 'event_sandbox',
+            'apiEnvironment' => 'sandbox',
+            'isSandbox'      => true,
+            'companySession' => 'company-uuid',
+        ], $record, new ResourceLifecycleWebhookListenerSessionSpyResource($record)));
+
+        $listener->handle(resource_lifecycle_webhook_listener_event([
+            'eventId'        => 'event_live',
+            'apiEnvironment' => 'live',
+            'isSandbox'      => false,
+            'companySession' => 'company-uuid',
+        ], $record, new ResourceLifecycleWebhookListenerSessionSpyResource($record)));
+
+        expect($bus->jobs)->toHaveCount(2)
+            ->and($bus->jobs[0]->meta['webhook_uuid'])->toBe('webhook-sandbox')
+            ->and($bus->jobs[0]->meta['is_sandbox'])->toBeTrue()
+            ->and($bus->jobs[1]->meta['webhook_uuid'])->toBe('webhook-enabled')
+            ->and($bus->jobs[1]->meta['is_sandbox'])->toBeFalse();
+
+        $observed = ResourceLifecycleWebhookListenerSessionSpyResource::$observed;
+
+        expect($observed[0]['api_environment'])->toBe('sandbox')
+            ->and($observed[0]['is_sandbox'])->toBeTrue()
+            ->and($observed[1]['api_environment'])->toBe('live')
+            ->and($observed[1]['is_sandbox'])->toBeFalse()
+            ->and(session()->has('is_sandbox'))->toBeFalse()
+            ->and(session()->has('company'))->toBeFalse();
     });
 
     test('resource lifecycle webhook listener logs failed sandbox dispatches with access token context', function () {
         [$capsule, $bus] = resource_lifecycle_webhook_listener_database();
 
         config()->set('webhook-server.signer', ResourceLifecycleWebhookListenerFailingSigner::class);
-        session()->put('api_credential', '44');
-        session()->put('api_environment', 'sandbox');
-        session()->put('is_sandbox', true);
 
-        $record = new FleetbaseModel();
-        $record->setRawAttributes([
-            'uuid'         => 'record-uuid',
-            'public_id'    => 'order_1234567',
-            'company_uuid' => 'company-uuid',
-            'status'       => 'dispatched',
-        ], true);
+        // stale live context from a previously handled event must not redirect this sandbox event
+        session()->put('api_credential', '11111111-1111-4111-8111-111111111111');
+        session()->put('api_environment', 'live');
+        session()->put('is_sandbox', false);
 
-        $event = ResourceLifecycleWebhookListenerEvent::fake([
-            'modelName'           => 'order',
-            'modelClassNamespace' => FleetbaseModel::class,
-            'modelClassName'      => 'Order',
-            'modelHumanName'      => 'order',
-            'modelUuid'           => 'record-uuid',
-            'namespace'           => '\\Fleetbase',
-            'version'             => 1,
-            'eventName'           => 'updated',
-            'sentAt'              => '2026-07-18 15:25:00',
-            'eventId'             => 'event_lifecycle',
-            'apiVersion'          => 'v1',
-            'requestMethod'       => 'PATCH',
-            'apiCredential'       => null,
-            'apiSecret'           => 'event-secret',
-            'apiKey'              => 'event-api-key',
-            'apiEnvironment'      => 'live',
-            'isSandbox'           => false,
-            'data'                => [],
-            'userSession'         => null,
-            'companySession'      => 'company-uuid',
-        ], $record, new ResourceLifecycleWebhookListenerResource($record));
+        $event = resource_lifecycle_webhook_listener_event([
+            'apiCredential'  => '44',
+            'apiEnvironment' => 'sandbox',
+            'isSandbox'      => true,
+        ]);
 
         (new SendResourceLifecycleWebhook())->handle($event);
 
@@ -608,38 +762,10 @@ namespace {
         [$capsule, $bus] = resource_lifecycle_webhook_listener_database();
 
         config()->set('webhook-server.signer', ResourceLifecycleWebhookListenerFailingSigner::class);
-        session()->put('api_credential', '11111111-1111-4111-8111-111111111111');
 
-        $record = new FleetbaseModel();
-        $record->setRawAttributes([
-            'uuid'         => 'record-uuid',
-            'public_id'    => 'order_1234567',
-            'company_uuid' => 'company-uuid',
-            'status'       => 'dispatched',
-        ], true);
-
-        $event = ResourceLifecycleWebhookListenerEvent::fake([
-            'modelName'           => 'order',
-            'modelClassNamespace' => FleetbaseModel::class,
-            'modelClassName'      => 'Order',
-            'modelHumanName'      => 'order',
-            'modelUuid'           => 'record-uuid',
-            'namespace'           => '\\Fleetbase',
-            'version'             => 1,
-            'eventName'           => 'updated',
-            'sentAt'              => '2026-07-18 15:25:00',
-            'eventId'             => 'event_lifecycle',
-            'apiVersion'          => 'v1',
-            'requestMethod'       => 'PATCH',
-            'apiCredential'       => null,
-            'apiSecret'           => 'event-secret',
-            'apiKey'              => 'event-api-key',
-            'apiEnvironment'      => 'live',
-            'isSandbox'           => false,
-            'data'                => [],
-            'userSession'         => null,
-            'companySession'      => 'company-uuid',
-        ], $record, new ResourceLifecycleWebhookListenerResource($record));
+        $event = resource_lifecycle_webhook_listener_event([
+            'apiCredential' => '11111111-1111-4111-8111-111111111111',
+        ]);
 
         (new SendResourceLifecycleWebhook())->handle($event);
 


### PR DESCRIPTION
Fixes #244.

## The bug

`SendResourceLifecycleWebhook::setSessionFromEvent()` only wrote a session key when it was **absent**, and `handle()` then **preferred** the session value over the event's:

```php
if (!session()->has('api_secret')) {
    session()->put('api_secret', $event->apiSecret);
}
// ...
$apiSecret = session()->get('api_secret', $event->apiSecret ?? 'internal');
```

A `queue:work` process is long-running and its session store is a container singleton, so it survives between jobs. Once the worker handled one lifecycle event, every later event reused that first event's `api_secret` — signing outbound webhooks with the wrong HMAC key — plus its `api_credential`, `api_key`, `api_environment`, `is_sandbox`, `company` and `user`. Restarting the worker only masked it.

The reporter verified this against Fleetbase API `v0.7.53` / `core-api` `v1.6.55`, and the same logic was still present on `v1.6.59`.

## The fix

The context serialized onto the event is now authoritative for the job that carries it:

- `resolveEventContext()` resolves the event's context once, applying the defaults (`console` / `internal` / `live`) explicitly instead of relying on `session()->get()`'s fallback argument, which never fired for a key that was present-but-stale.
- The webhook body, signature, `ApiEvent` row and `WebhookRequestLog` are all built from that resolved context — no session reads in the send path.
- The context is still written to the session unconditionally, because downstream code (model scopes, observers, resources) reads it from there — but only for the duration of the job. A restorer returned by `setSessionFromEvent()` runs in a `finally`, putting back whatever the session held before and removing keys that were not set, so the next job starts clean and a synchronous (non-queued) run no longer leaves `api_secret`/`api_credential` behind in a real user's session.

`setSessionFromEvent($event)` stays public and keeps its signature; it now overwrites rather than backfills, and returns the restore callable.

## Tests

`vendor/bin/pest` — 1415 passed. The 6 failures in `Tests\Unit\Http\RequestContractsTest` and `RequestValidationBehaviorTest` are pre-existing and reproduce identically on `main`; they are unrelated to this change. `php-cs-fixer` and `phpstan` are clean on the touched files.

Four tests cover the report, and all four fail against the unpatched listener:

- **signs each queued event with its own secret** — two events handled back to back by the same listener instance in one session; each dispatched job's `X-Fleetbase-Signature` is asserted to equal the HMAC of its own payload under its own secret, and to *not* equal the HMAC under the other event's secret.
- **does not leak environment sandbox or company context between queued events** — a sandbox event followed by a live one; each is asserted to reach the endpoint for its own mode.
- **restores the previous session context after handling an event** — a spy resource records the session as downstream code sees it mid-job, covering `api_credential`, `api_key`, `api_secret`, `api_environment`, `is_sandbox`, `company` and `user`; the session is then asserted to be handed back exactly as it was found.
- **prefers event credential attribution over a stale worker session** — stale credential/key/secret in the session are asserted not to reach the `ApiEvent` row, the job meta, or the signature.

Three existing tests asserted the old precedence (session wins) and were re-pointed at the event-authoritative behavior; their coverage of failure logging and credential attribution is unchanged, with the context moved from the session onto the event.

## Note, not addressed here

`ResourceLifecycleEvent::broadcastOn()` reads `session('company')` and `session('api_credential')` at broadcast time, which has the same worker-session exposure. It is left alone deliberately: the event's `apiCredential` defaults to `'console'` rather than being absent, so switching it over would start adding an `api.console` channel to every console-originated broadcast. That is a separate change with its own blast radius on the realtime layer, and worth its own issue.
