### PR TITLE
fix(auth): api credentials survived revocation and creator removal

### DIFF
--- a/src/Http/Middleware/AuthenticateOnceWithBasicAuth.php
+++ b/src/Http/Middleware/AuthenticateOnceWithBasicAuth.php
@@ -82,6 +82,18 @@ class AuthenticateOnceWithBasicAuth
             return response()->error('Oops! The api credentials provided were not valid', 401);
         }
 
+        // Credentials have been revoked.
+        //
+        // withoutGlobalScopes() above strips SoftDeletingScope along with ExpiryScope, so
+        // the lookup deliberately sees deleted rows. Expiry is re-applied in PHP below, but
+        // soft-deletion never was — a credential the console reports as "Deleted" kept
+        // authenticating indefinitely, and Delete was the only revocation most operators
+        // ever performed. Treated as "not valid" rather than a distinct message so a caller
+        // cannot distinguish a revoked key from one that never existed.
+        if ($apiCredential->trashed()) {
+            return response()->error('Oops! The api credentials provided were not valid', 401);
+        }
+
         // If OPTIONS set api key and continue
         if ($request->isMethod('OPTIONS')) {
             // Set api credential session
@@ -96,7 +108,13 @@ class AuthenticateOnceWithBasicAuth
         }
 
         // Login user
-        Auth::setSession($apiCredential);
+        //
+        // Fails when the credential's creating user no longer resolves — the credential has
+        // no identity to act as, so the request is rejected rather than continuing with a
+        // half-populated session.
+        if (Auth::setSession($apiCredential) !== true) {
+            return response()->error('Oops! The api credentials provided were not valid', 401);
+        }
 
         // Bind the user resolver so $request->user() answers on the public API.
         //

--- a/src/Support/Auth.php
+++ b/src/Support/Auth.php
@@ -62,14 +62,25 @@ class Auth extends Authentication
 
         if ($user instanceof ApiCredential) {
             $apiCredential = $user;
-            session(['company' => $apiCredential->company_uuid, 'user' => $apiCredential->user_uuid]);
-            // user couldn't be loaded, fallback with api credential if applicable
-            $user = User::find($apiCredential->user_uuid);
 
-            // Set is admin if user of api credential is admin
-            if ($user) {
-                session(['is_admin' => $user->isAdmin()]);
+            // An API credential carries no identity of its own — it acts as the user that
+            // created it. When that user no longer resolves (hard or soft deleted) there is
+            // no identity to run as, so authentication must fail closed.
+            //
+            // This previously fell through and returned true with `is_admin` simply never
+            // set. Authorization degraded safely, but authentication did not: the key kept
+            // working on every read endpoint and every ungated write, so off-boarding a
+            // person did not revoke the keys they had created.
+            $user = User::find($apiCredential->user_uuid);
+            if (!$user instanceof User) {
+                return false;
             }
+
+            session([
+                'company'  => $apiCredential->company_uuid,
+                'user'     => $apiCredential->user_uuid,
+                'is_admin' => $user->isAdmin(),
+            ]);
 
             // track last usage of api credential
             $apiCredential->trackLastUsed();

--- a/src/Traits/Expirable.php
+++ b/src/Traits/Expirable.php
@@ -88,7 +88,12 @@ trait Expirable
         $column = $this->getExpiredAtColumn();
 
         if (is_object($this->{$column})) {
-            return $this->{$column} < Carbon::now();
+            // Inclusive, to agree with ExpiryScope, which keeps a row only while
+            // `expires_at > now()` and therefore already treats an exactly-now expiry as
+            // expired. A strict `<` here disagreed with the scope on that boundary, which
+            // is precisely the value ApiCredential writes for the console's "immediately"
+            // option (Carbon::now()) — so "expire this key right now" left it valid.
+            return $this->{$column} <= Carbon::now();
         }
 
         return false;

--- a/tests/Unit/Http/MiddlewareContractsTest.php
+++ b/tests/Unit/Http/MiddlewareContractsTest.php
@@ -67,6 +67,14 @@ namespace {
         protected array $except = ['health'];
     }
 
+    class MiddlewareContractsBasicAuthHarness extends AuthenticateOnceWithBasicAuth
+    {
+        public static function bindUserResolverPublic(?Request $request, $user): void
+        {
+            static::bindUserResolver($request, $user);
+        }
+    }
+
     class MiddlewareContractsCustomMiddlewareHarness
     {
         use Fleetbase\Traits\CustomMiddleware;
@@ -1211,6 +1219,34 @@ namespace {
             ->and(session('company'))->toBeNull()
             ->and(session('api_credential'))->toBeNull()
             ->and($capsule->getConnection('mysql')->table('api_credentials')->where('uuid', 'credential-orphaned')->value('last_used_at'))->toBeNull();
+    });
+
+    test('basic auth middleware user resolver binding refuses incomplete arguments', function () {
+        // bindUserResolver() is protected static, so a downstream middleware subclass can
+        // call it with whatever it has. Neither in-tree call site can reach this guard --
+        // the sanctum path checks `tokenable instanceof User` first, and the credential
+        // path now fails closed before it -- but the guard still has to hold for callers
+        // that are not this class.
+        middleware_contracts_basic_auth_database();
+
+        $request = Request::create('/v1/orders', 'GET');
+        $user    = new FleetbaseUser();
+        $user->setRawAttributes(['uuid' => 'user-1'], true);
+
+        // No request to bind onto.
+        MiddlewareContractsBasicAuthHarness::bindUserResolverPublic(null, $user);
+
+        // No user to bind -- must not install a resolver that yields null, which would
+        // shadow a guard that resolves the user later in the stack.
+        MiddlewareContractsBasicAuthHarness::bindUserResolverPublic($request, null);
+
+        expect($request->user())->toBeNull();
+
+        // The positive case still binds, so the guard is not simply rejecting everything.
+        MiddlewareContractsBasicAuthHarness::bindUserResolverPublic($request, $user);
+
+        expect($request->user())->toBeInstanceOf(FleetbaseUser::class)
+            ->and($request->user()->uuid)->toBe('user-1');
     });
 
     test('basic auth middleware falls back to sandbox for sdk secret keys', function () {

--- a/tests/Unit/Http/MiddlewareContractsTest.php
+++ b/tests/Unit/Http/MiddlewareContractsTest.php
@@ -348,6 +348,16 @@ namespace {
             ['uuid' => 'sanctum-user-invalid-company', 'company_uuid' => 'company-1', 'type' => 'user'],
             ['uuid' => 'sanctum-user-valid-company', 'company_uuid' => '550e8400-e29b-41d4-a716-446655440000', 'type' => 'user'],
             ['uuid' => 'sanctum-user-token-fallback', 'company_uuid' => '550e8400-e29b-41d4-a716-446655440001', 'type' => 'driver'],
+            // The User model is pinned to the mysql connection (User::$connection), and
+            // production is authoritative for users — the sandbox schema only holds a
+            // mirror maintained by sandbox:sync. So a sandbox credential's creator is
+            // resolved here, not on the sandbox connection.
+            ['uuid' => 'sandbox-user-1', 'company_uuid' => 'sandbox-company-1', 'type' => 'admin'],
+        ]);
+        // An off-boarded creator: the row still exists, but soft-deleted, so User::find()
+        // no longer resolves it.
+        $db->table('users')->insert([
+            ['uuid' => 'user-gone', 'company_uuid' => 'company-1', 'type' => 'admin', 'deleted_at' => '2026-07-19 00:00:00'],
         ]);
         $db->table('companies')->insert([
             ['uuid' => 'company-1', 'owner_id' => 'user-1', 'owner_uuid' => 'user-1'],
@@ -358,6 +368,12 @@ namespace {
             ['uuid' => 'credential-live', 'user_uuid' => 'user-1', 'company_uuid' => 'company-1', 'name' => 'Live', 'key' => 'flb_live_auth', 'secret' => '$live_secret', 'test_mode' => 0, 'last_used_at' => null, 'expires_at' => null, 'created_at' => '2026-07-18 00:00:00', 'updated_at' => '2026-07-18 00:00:00'],
             ['uuid' => 'credential-expired', 'user_uuid' => 'user-1', 'company_uuid' => 'company-1', 'name' => 'Expired', 'key' => 'flb_live_expired', 'secret' => '$expired_secret', 'test_mode' => 0, 'last_used_at' => null, 'expires_at' => '2020-01-01 00:00:00', 'created_at' => '2026-07-18 00:00:00', 'updated_at' => '2026-07-18 00:00:00'],
             ['uuid' => 'credential-sanctum', 'user_uuid' => 'sanctum-user-valid-company', 'company_uuid' => '550e8400-e29b-41d4-a716-446655440000', 'name' => 'Sanctum', 'key' => 'flb_live_sanctum', 'secret' => '$sanctum_secret', 'test_mode' => 0, 'last_used_at' => null, 'expires_at' => null, 'created_at' => '2026-07-18 00:00:00', 'updated_at' => '2026-07-18 00:00:00'],
+        ]);
+        // Revoked (soft-deleted, and carrying no expiry) and orphaned (its creating user
+        // has been off-boarded) credentials.
+        $db->table('api_credentials')->insert([
+            ['uuid' => 'credential-revoked', 'user_uuid' => 'user-1', 'company_uuid' => 'company-1', 'name' => 'Revoked', 'key' => 'flb_live_revoked', 'secret' => '$revoked_secret', 'test_mode' => 0, 'last_used_at' => null, 'expires_at' => null, 'created_at' => '2026-07-18 00:00:00', 'updated_at' => '2026-07-18 00:00:00', 'deleted_at' => '2026-07-19 00:00:00'],
+            ['uuid' => 'credential-orphaned', 'user_uuid' => 'user-gone', 'company_uuid' => 'company-1', 'name' => 'Orphaned', 'key' => 'flb_live_orphaned', 'secret' => '$orphaned_secret', 'test_mode' => 0, 'last_used_at' => null, 'expires_at' => null, 'created_at' => '2026-07-18 00:00:00', 'updated_at' => '2026-07-18 00:00:00', 'deleted_at' => null],
         ]);
         $db->table('personal_access_tokens')->insert([
             ['id' => 1, 'tokenable_type' => FleetbaseUser::class, 'tokenable_id' => 'sanctum-user-invalid-company', 'name' => 'invalid-company', 'token' => hash('sha256', 'plain-invalid-company-token'), 'abilities' => json_encode(['*']), 'created_at' => '2026-07-18 00:00:00', 'updated_at' => '2026-07-18 00:00:00'],
@@ -1108,6 +1124,93 @@ namespace {
             ->and($expiredResponse->getData(true))->toBe([
                 'errors' => ['Oops! These api credentials have expired'],
             ]);
+    });
+
+    test('basic auth middleware rejects revoked credentials', function () {
+        // The credential lookup uses withoutGlobalScopes(), which strips SoftDeletingScope
+        // along with ExpiryScope. Expiry is re-applied in PHP; soft-deletion was not, so a
+        // credential the console reports as "Deleted" authenticated indefinitely. It also
+        // carries no expiry here, so nothing else could catch it.
+        $capsule = middleware_contracts_basic_auth_database();
+        session()->flush();
+
+        $request = Request::create('/v1/orders', 'GET', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer flb_live_revoked',
+        ]);
+        $continued = false;
+        $response  = (new AuthenticateOnceWithBasicAuth())->handle(
+            $request,
+            function () use (&$continued) {
+                $continued = true;
+
+                return new JsonResponse(['ok' => true]);
+            }
+        );
+
+        expect($continued)->toBeFalse()
+            ->and($response->getStatusCode())->toBe(401)
+            ->and($response->getData(true))->toBe([
+                'errors' => ['Oops! The api credentials provided were not valid'],
+            ])
+            ->and(session('api_credential'))->toBeNull()
+            ->and(session('user'))->toBeNull()
+            ->and($capsule->getConnection('mysql')->table('api_credentials')->where('uuid', 'credential-revoked')->value('last_used_at'))->toBeNull();
+    });
+
+    test('basic auth middleware rejects revoked credentials on preflight requests', function () {
+        // Rejected before the OPTIONS shortcut, so a revoked key cannot seed api key
+        // session context on a preflight either.
+        middleware_contracts_basic_auth_database();
+        session()->flush();
+
+        $request = Request::create('/v1/orders', 'OPTIONS', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer flb_live_revoked',
+        ]);
+        $continued = false;
+        $response  = (new AuthenticateOnceWithBasicAuth())->handle(
+            $request,
+            function () use (&$continued) {
+                $continued = true;
+
+                return new JsonResponse(['preflight' => true]);
+            }
+        );
+
+        expect($continued)->toBeFalse()
+            ->and($response->getStatusCode())->toBe(401)
+            ->and(session('api_credential'))->toBeNull();
+    });
+
+    test('basic auth middleware fails closed when the credential creator no longer resolves', function () {
+        // A credential acts as the user that created it. Once that user is soft-deleted
+        // there is no identity to run as, and the request must be rejected — previously
+        // `is_admin` was simply never set and authentication still succeeded, so
+        // off-boarding a person left every key they had created working.
+        $capsule = middleware_contracts_basic_auth_database();
+        session()->flush();
+
+        $request = Request::create('/v1/orders', 'GET', [], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer flb_live_orphaned',
+        ]);
+        $continued = false;
+        $response  = (new AuthenticateOnceWithBasicAuth())->handle(
+            $request,
+            function () use (&$continued) {
+                $continued = true;
+
+                return new JsonResponse(['ok' => true]);
+            }
+        );
+
+        expect($continued)->toBeFalse()
+            ->and($response->getStatusCode())->toBe(401)
+            ->and($response->getData(true))->toBe([
+                'errors' => ['Oops! The api credentials provided were not valid'],
+            ])
+            ->and(session('user'))->toBeNull()
+            ->and(session('company'))->toBeNull()
+            ->and(session('api_credential'))->toBeNull()
+            ->and($capsule->getConnection('mysql')->table('api_credentials')->where('uuid', 'credential-orphaned')->value('last_used_at'))->toBeNull();
     });
 
     test('basic auth middleware falls back to sandbox for sdk secret keys', function () {

--- a/tests/Unit/Support/AuthSupportTest.php
+++ b/tests/Unit/Support/AuthSupportTest.php
@@ -688,6 +688,21 @@ test('auth support stores api credential session context and tracks key usage', 
         ->and(Auth::getApiKey()->uuid)->toBe($credential->uuid);
 });
 
+test('auth support fails closed when an api credential creator no longer resolves', function () {
+    [$admin, , $credential] = auth_support_fixtures();
+
+    // Off-board the creating user. A credential has no identity of its own — it acts as
+    // its creator — so there is nothing left for it to run as. This used to return true
+    // with `is_admin` merely unset, leaving the key live on every read endpoint.
+    app('db')->table('users')->where('uuid', $admin->uuid)->update(['deleted_at' => '2026-07-17 11:00:00']);
+
+    expect(Auth::setSession($credential))->toBeFalse()
+        ->and(session('user'))->toBeNull()
+        ->and(session('company'))->toBeNull()
+        ->and(session('is_admin'))->toBeNull()
+        ->and(app('db')->table('api_credentials')->where('uuid', $credential->uuid)->value('last_used_at'))->toBeNull();
+});
+
 test('auth support returns null when no api credential session exists', function () {
     auth_support_fixtures();
 

--- a/tests/Unit/Traits/LifecycleTraitsTest.php
+++ b/tests/Unit/Traits/LifecycleTraitsTest.php
@@ -282,8 +282,15 @@ test('expirable reports expiry ttl timestamp and qualified columns', function ()
     $expired = new LifecycleTraitsExpirableRecord([
         'expires_at' => Carbon::now()->subMinute(),
     ]);
+    // ExpiryScope keeps a row only while `expires_at > now()`, so an exactly-now expiry is
+    // already excluded from queries — hasExpired() has to agree. This is the value written
+    // for the console's "expire immediately" option.
+    $expiredNow = new LifecycleTraitsExpirableRecord([
+        'expires_at' => Carbon::now(),
+    ]);
 
-    expect($active->hasExpired())->toBeFalse()
+    expect($expiredNow->hasExpired())->toBeTrue()
+        ->and($active->hasExpired())->toBeFalse()
         ->and($active->timeToLive())->toBe(300)
         ->and($active->expiresAtTimestamp())->toBe(Carbon::now()->addMinutes(5)->timestamp)
         ->and($active->getExpiredAtColumn())->toBe('expires_at')


### PR DESCRIPTION
## Summary

Three defects on the API credential authentication path in `AuthenticateOnceWithBasicAuth` / `Auth::setSession()` / `Expirable`. Each one leaves a credential live that an operator has good reason to believe is dead. Taken together, a stock Fleetbase console has **no working way to revoke an API credential**: Delete doesn't revoke, and "expire immediately" doesn't expire.

Reported by a downstream deployment against 1.6.35; every reference below re-verified against `main` (1.6.59). Private tracker: `FliitAU/fliit-extension#2212`.

---

### 1. Soft-deleted credentials still authenticate

`AuthenticateOnceWithBasicAuth.php:63-66` looks the credential up with `withoutGlobalScopes()`, which strips **both** of `ApiCredential`'s global scopes — `SoftDeletingScope` (from the base `Fleetbase\Models\Model`) and `ExpiryScope` (from `Expirable`). Expiry is then re-applied in PHP at `:94` via `hasExpired()`. Soft-deletion never was.

So a credential the console reports as **Deleted** keeps authenticating indefinitely, while the console hides the row from the UI. Delete is the only revocation most operators ever perform.

This is not theoretical: a downstream production database held a credential soft-deleted on 2026-06-12 with `expires_at` null, still authenticating 48 days later on stock behaviour. It was created, deleted as a mistake, and recreated under the same name — and credential names are not unique, so the console list gave the operator no way to tell the two rows apart.

**Fix:** reject `trashed()` credentials with the generic `not valid` 401, placed *before* the `OPTIONS` shortcut so a revoked key cannot seed api key session context on a preflight either. The message is deliberately not distinct from "no such key" so a caller cannot probe for revoked-but-real keys.

### 2. Authentication is fail-open when the creating user is gone

`Auth::setSession()` at `src/Support/Auth.php:63-78`. An API credential carries no identity of its own — it acts as the user that created it. When `User::find()` no longer resolves that user (deleted, or soft-deleted on off-boarding), the `if ($user)` guard is skipped so `is_admin` is never set — but `setSession()` still returns `true`.

Authorization degrades safely: a null user fails every group and admin check. **Authentication does not.** The key keeps working on every read endpoint and every ungated write. Off-boarding a person therefore does not revoke the authority of the keys they created.

**Fix:** `setSession()` returns `false` when the credential's user does not resolve, and the middleware answers a clean 401 — the same shape an expired credential gets. The session is no longer half-populated on the way out, and `trackLastUsed()` is not called for a rejected request.

Worth noting for review: `User` declares `protected $connection = 'mysql'` (`src/Models/User.php:76`), and `sandbox:sync` mirrors `mysql → sandbox`, so production is authoritative for users. Sandbox credentials therefore resolve their creator against the same authoritative store and are unaffected. `tests/Unit/Http/MiddlewareContractsTest.php` previously seeded `sandbox-user-1` only on the sandbox connection, which did not reflect that; the fixture now mirrors it to `mysql` as the real system does, and the sandbox secret-key test still passes.

### 3. "Expire immediately" does not expire the credential

`ApiCredential::setExpiresAtAttribute()` maps the console's `'immediately'` option to `Carbon::now()` (`src/Models/ApiCredential.php:144`), but `Expirable::hasExpired()` used a strict `<` (`src/Traits/Expirable.php:91`) — `now() < now()` is false.

`ExpiryScope` already disagreed with it: it keeps a row only while `expires_at > now()` (`src/Scopes/ExpiryScope.php:26`), i.e. it treats an exactly-now expiry as expired. The trait and the scope were on opposite sides of the same boundary.

**Fix:** `hasExpired()` is now inclusive (`<=`), which makes the two agree and makes "expire this key right now" actually take effect.

---

## Not addressed here

- **Per-key roles / scopes.** A credential still has no scope of its own — `Auth::setSession()` derives `is_admin` from whoever clicked "Create", so every key an admin creates is a full-admin key regardless of its name. Least privilege is only reachable indirectly, by scoping the *creator* into a dedicated service user. `ApiCredential` already uses `HasPolicies` and `HasPermissions`, so the plumbing partly exists but nothing on the auth path consults it. That's a feature, not a fix, and wants a design discussion — happy to open a separate issue.
- **Console expiry dropdown serializes every option to `null`.** That one is in `dev-engine` (`api-credential.js` declares `@attr('date') expires_at` while the form assigns relative strings), not this repo.

## Testing

`php vendor/bin/pest` — **1422 passed, 0 failed** (9966 assertions). `php-cs-fixer` clean.

New coverage:
- revoked credential rejected on a normal request, with no session context and no `last_used_at` write
- revoked credential rejected on an `OPTIONS` preflight
- credential whose creator has been soft-deleted rejected, with no session context and no `last_used_at` write
- `Auth::setSession()` returns `false` for an orphaned credential (unit level, `AuthSupportTest`)
- `hasExpired()` is true at an exactly-now expiry (`LifecycleTraitsTest`)

## Compatibility

`Auth::setSession()` can now return `false` for an `ApiCredential` whose user is gone. The only in-tree caller that passes an `ApiCredential` is this middleware; the `User` branch is untouched. Any deployment currently relying on credentials outliving their creator will see those keys start returning 401 — which is the intent.
