### PR TITLE
Bugfix: Utils::apiUrl renders query params as path segments

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -38,7 +38,9 @@ class Utils
     public static function apiUrl(string $path, ?array $queryParams = [], int $port = 80): string
     {
         $isLocalDevelopment = app()->environment(['local', 'development']);
-        $baseURL            = url($path, $queryParams, !$isLocalDevelopment);
+        // Laravel's url() renders extra parameters as path segments, not a query string,
+        // so the query string must be built here
+        $baseURL = url($path, [], !$isLocalDevelopment);
 
         // Check if default port is used to avoid appending it unnecessarily
         if (!in_array($port, [80, 443])) {
@@ -50,6 +52,10 @@ class Utils
                 // Insert port after the host
                 $baseURL = str_replace($parsedUrl['host'], $parsedUrl['host'] . $portString, $baseURL);
             }
+        }
+
+        if (!empty($queryParams)) {
+            $baseURL .= (str_contains($baseURL, '?') ? '&' : '?') . http_build_query($queryParams);
         }
 
         return $baseURL;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -311,11 +311,15 @@ namespace {
     if (!function_exists('url')) {
         function url(string $path = '', mixed $parameters = [], ?bool $secure = null): string
         {
+            // Mirrors Illuminate\Routing\UrlGenerator::to(): extra parameters become
+            // rawurlencoded path segments with keys discarded, NOT a query string
             $base = $secure ? 'https://fleetbase.test' : 'http://fleetbase.test';
             $path = '/' . ltrim($path, '/');
 
             if (is_array($parameters) && $parameters !== []) {
-                return $base . $path . '?' . http_build_query($parameters);
+                $tail = implode('/', array_map('rawurlencode', array_values($parameters)));
+
+                return $base . rtrim($path, '/') . '/' . $tail;
             }
 
             return $base . $path;


### PR DESCRIPTION
## Problem

`Utils::apiUrl()` passed its `$queryParams` array straight through to Laravel's `url($path, $parameters, $secure)`. Laravel's `UrlGenerator::to()` renders those extra parameters as **rawurlencoded path segments with the keys discarded** — it has never built a query string:

```php
Utils::apiUrl('/api/user', ['id' => 1]);
// expected (per docblock): https://host/api/user?id=1
// actual:                  https://host/api/user/1
```

This silently broke every caller that passes query params. Known affected call sites:

- `storefront` — the QPay payment callback URL (`CheckoutController.php:768`) came out as `.../capture-qpay/checkout_xxx`, which matches no route, so QPay's server-side payment notification 404s (context: fleetbase/storefront#90).
- `solid` — the OIDC complete-registration URL (`SolidIdentity.php:74`).

## Why tests never caught it

The Pest bootstrap runs without booting Laravel and defines its own fallback `url()` shim, which implemented the query-string behavior the docblock *promises* rather than the path-segment behavior Laravel actually has — so `UtilsTest` asserted `?id=1` against the fake and passed.

## Fix

- `Utils::apiUrl()` now calls `url($path, [], $secure)` and appends the query string itself with `http_build_query()` (after the custom-port insertion, and with a `&` join if the path already carries a query string). Path-only callers are unaffected.
- The test shim now mirrors `UrlGenerator::to()`'s real path-segment semantics, so the suite can no longer mask this divergence; the existing `UtilsTest` query-string assertions now pass because `apiUrl` itself builds the query string.

`consoleUrl()` was already correct (builds its own query string) and is untouched.

## Verification

- Ran the vendored `Illuminate\Routing\UrlGenerator` standalone to confirm the real `url()` behavior before the fix.
- Full Pest suite: **1426 passed (10013 assertions)**, no failures.