### PR TITLE
fix: add the report execution statistics columns

### DIFF
--- a/migrations/2026_08_31_000000_add_report_execution_statistics_columns.php
+++ b/migrations/2026_08_31_000000_add_report_execution_statistics_columns.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Add the running-statistics columns Report::updateExecutionStats writes.
+     *
+     * The report builder's execution statistics were written but never migrated.
+     * `Report::updateExecutionStats()` sets `execution_count`, `average_execution_time`
+     * and `last_result_count` on every run, `getPerformanceMetrics()` returns all three,
+     * and `cloneWithConfig()` resets them — but the reports table has none of them, so
+     * the save at the end of updateExecutionStats fails:
+     *
+     *     SQLSTATE[42S22]: Column not found: 1054
+     *     Unknown column 'execution_count' in 'field list'
+     *
+     * The effect is that **every saved report fails to execute**, in every extension.
+     * The query itself succeeds — the failure happens afterwards, while recording that
+     * it ran — so the caller sees an error for a report that actually worked, and the
+     * report builder's preview shows an empty result with no explanation.
+     *
+     * These are distinct from `execution_time` and `row_count`, which
+     * 2025_09_25_084135_report_enhancements added and the API resource exposes: those
+     * describe the last run, while these accumulate across runs.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reports', function (Blueprint $table) {
+            $table->unsignedInteger('execution_count')->default(0)->after('row_count');
+
+            // A mean of integer millisecond timings, so it needs somewhere for the
+            // fraction to go — `execution_time` is an integer because it holds one
+            // measurement rather than an average of several.
+            $table->float('average_execution_time')->nullable()->comment('Mean execution time in milliseconds across all runs')->after('execution_count');
+
+            $table->integer('last_result_count')->nullable()->after('average_execution_time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reports', function (Blueprint $table) {
+            $table->dropColumn([
+                'execution_count',
+                'average_execution_time',
+                'last_result_count',
+            ]);
+        });
+    }
+};

--- a/tests/Unit/Models/ReportExecutionColumnsTest.php
+++ b/tests/Unit/Models/ReportExecutionColumnsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Every attribute Report persists must have a column to land in.
+ *
+ * `updateExecutionStats()` sets execution_count, average_execution_time and
+ * last_result_count and then calls save(). None of the three had a column, so the save
+ * threw and **every saved report failed to execute** — after its query had already
+ * succeeded, which made it look like the query was at fault.
+ *
+ * ReportModelTest covers the arithmetic thoroughly and could not catch this: it drives
+ * the model through a spy whose save() is a counter, so nothing it does reaches a
+ * schema. This test closes that specific gap by reading the migrations rather than the
+ * database, so it needs no connection and runs in the same pure-unit suite.
+ */
+function reportsTableColumns(): array
+{
+    $columns = [];
+
+    foreach (glob(__DIR__ . '/../../../migrations/*.php') as $migration) {
+        $source = file_get_contents($migration);
+
+        // Read only up(). A down() names the same columns in its dropColumn, and
+        // counting those alongside the additions cancelled them straight back out.
+        if (!preg_match('/function up\(\).*?(?=\n    \/\*\*|\n    public function down)/s', $source, $upBody)) {
+            continue;
+        }
+
+        // Only the blueprints that build or alter `reports` — the reporting feature also
+        // has report_executions, report_cache and report_audit_logs tables, several of
+        // which legitimately do have their own execution_time.
+        if (!preg_match_all("/Schema::(?:create|table)\(\s*'reports'\s*,.*?\n        \}\);/s", $upBody[0], $blocks)) {
+            continue;
+        }
+
+        foreach ($blocks[0] as $block) {
+            preg_match_all("/\\\$table->[A-Za-z]+\(\s*'([a-z0-9_]+)'/", $block, $found);
+            $columns = array_merge($columns, $found[1]);
+        }
+    }
+
+    return array_unique($columns);
+}
+
+it('has a column for every execution statistic the report model writes', function () {
+    $columns = reportsTableColumns();
+
+    expect($columns)->not->toBeEmpty('no reports blueprints were found to read');
+
+    foreach (['execution_count', 'average_execution_time', 'last_result_count', 'last_executed_at'] as $column) {
+        expect($columns)->toContain($column);
+    }
+});
+
+it('still has the per-run columns the api resource exposes', function () {
+    // execution_time and row_count describe the last run and are returned by the Report
+    // resource; the statistics above accumulate across runs. Both sets must exist —
+    // adding one must not be mistaken for replacing the other.
+    $columns = reportsTableColumns();
+
+    expect($columns)->toContain('execution_time')
+        ->and($columns)->toContain('row_count');
+});


### PR DESCRIPTION
## The problem

**Every saved report fails to execute**, in core and in every extension.

`Report::updateExecutionStats()` sets three attributes and then saves:

```php
$this->execution_count        = ($this->execution_count ?? 0) + 1;
$this->average_execution_time = /* rolling mean */;
$this->last_result_count      = $resultCount;
$this->save();
```

The `reports` table has none of them, so the save throws:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'execution_count' in 'field list'
```

The query has already succeeded by the time this runs — the failure is in recording *that* it ran. So a report that worked reports an error, and the builder's preview shows an empty result with nothing in the browser console to explain it. That last part is what makes it expensive to diagnose: it looks like the query returned nothing.

The builder's *preview* path (`POST /reports/execute-query`) never calls `updateExecutionStats`, so ad-hoc previews work fine and only **saved** reports fail. That asymmetry hides it further.

## Why a migration rather than changing the model

This is a feature that was written and never migrated, not a naming slip:

- `updateExecutionStats()` writes all three
- `getPerformanceMetrics()` returns all three
- `cloneWithConfig()` resets all three

They are also distinct from `execution_time` and `row_count`, which `2025_09_25_084135_report_enhancements` added and `Http/Resources/.../Report` exposes — those describe the **most recent** run, these **accumulate across** runs. Rewriting the model onto the existing columns would have discarded `execution_count` and the rolling average and broken the other two call sites.

`average_execution_time` is a `float` because it holds a mean of integer millisecond timings; `execution_time` is an integer because it holds one measurement.

## Not added to `$fillable`

The model maintains these itself. Making server-owned statistics mass-assignable would let a client set its own execution count, so they are set by assignment only.

## Test

`ReportModelTest` covers the rolling-average arithmetic thoroughly and **could not** have caught this: it drives the model through a spy whose `save()` is a counter, so nothing it does reaches a schema.

The new test closes that specific gap by reading the migrations rather than a database, so it needs no connection and stays in the pure-unit suite. It fails without the migration and passes with it:

```
✓ it has a column for every execution statistic the report model writes
✓ it still has the per-run columns the api resource exposes
```

The second assertion is there so a future change cannot mistake adding these for replacing `execution_time` / `row_count`.

## Verification

Against a running instance, before and after `php artisan migrate`:

| | before | after |
|---|---|---|
| 6 saved reports executed | all fail, missing-column error | all succeed, rows returned |
| `execution_count` | — | increments per run |
| `average_execution_time` | — | rolling mean updates |
| `getPerformanceMetrics()` | — | returns all three |

The builder preview that had been rendering empty now renders its rows.

## Note for the reviewer

`tests/Unit/Models/ReportModelTest.php` has one **pre-existing** failure on `main` (`BindingResolutionException` in the audit-record test) that is unrelated to this change and left alone — it fails identically with and without this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)